### PR TITLE
Update UI to match new nutrient DB format

### DIFF
--- a/UI.html
+++ b/UI.html
@@ -17,7 +17,7 @@
     <table id="db">
         <thead>
             <tr>
-                <th>Выбрать</th>
+                <th>Добавить</th>
                 <th>Продукт</th>
                 <th class="nutrient-col">Белки</th>
                 <th class="nutrient-col">Насыщенные</th>
@@ -27,8 +27,6 @@
                 <th class="nutrient-col">Растворимая</th>
                 <th class="nutrient-col">Нерастворимая</th>
                 <th class="nutrient-col">ККал</th>
-                <th>Макс. порций</th>
-                <th>Шаг</th>
             </tr>
         </thead>
         <tbody></tbody>
@@ -37,6 +35,7 @@
     <table id="pool">
         <thead>
             <tr>
+                <th>Удалить</th>
                 <th>Продукт</th>
                 <th class="nutrient-col">Белки</th>
                 <th class="nutrient-col">Насыщенные</th>
@@ -77,59 +76,70 @@
 
         function addToPool(name) {
             const existing = document.querySelector('#pool tbody tr[data-name="' + name + '"]');
-            if (!existing) {
-                const data = products[name] || {};
-                const tr = document.createElement('tr');
-                tr.setAttribute('data-name', name);
-                tr.innerHTML = `
-                    <td>${name}</td>
-                    <td class="nutrient-col">${data.proteins}</td>
-                    <td class="nutrient-col">${data.saturated}</td>
-                    <td class="nutrient-col">${data.unsaturated}</td>
-                    <td class="nutrient-col">${data.simple}</td>
-                    <td class="nutrient-col">${data.complex}</td>
-                    <td class="nutrient-col">${data.soluble}</td>
-                    <td class="nutrient-col">${data.insoluble}</td>
-                    <td class="nutrient-col">${data.kcal}</td>
-                    <td><input type="number" class="max-portions" min="0" step="1" value="${data.defaultMax || 0}"></td>
-                    <td><input type="number" class="step" min="0" step="0.1" value="${data.defaultStep || 0}"></td>
-                    <td class="max-weight"><span class="weight-value">0</span></td>
-                    <td><input type="checkbox" class="fix-weight"></td>
-                    <td><input type="checkbox" class="optimize"></td>
-                `;
-                poolBody.appendChild(tr);
-                updateNutrientVisibility();
-
-                const maxPortionsInput = tr.querySelector('.max-portions');
-                const stepInput = tr.querySelector('.step');
-                const weightValue = tr.querySelector('.weight-value');
-                const fixCheckbox = tr.querySelector('.fix-weight');
-                const maxWeightCell = tr.querySelector('.max-weight');
-                const optimizeCheckbox = tr.querySelector('.optimize');
-
-                function updateWeight() {
-                    const maxPortions = parseFloat(maxPortionsInput.value) || 0;
-                    const step = parseFloat(stepInput.value) || 0;
-                    const weight = maxPortions * step;
-                    weightValue.textContent = weight.toFixed(1);
-                }
-
-                maxPortionsInput.addEventListener('input', updateWeight);
-                stepInput.addEventListener('input', updateWeight);
-                updateWeight();
-
-                fixCheckbox.addEventListener('change', function() {
-                    maxWeightCell.style.backgroundColor = this.checked ? '#ffb6c1' : '';
-                });
-
-                optimizeCheckbox.addEventListener('change', function() {
-                    if (this.checked) {
-                        optimizationList.add(name);
-                    } else {
-                        optimizationList.delete(name);
-                    }
-                });
+            if (existing) {
+                alert('Продукт уже в пуле');
+                return;
             }
+
+            const data = products[name] || {};
+            const defaultMax = 10;
+            const defaultStep = 10;
+            const tr = document.createElement('tr');
+            tr.setAttribute('data-name', name);
+            tr.innerHTML = `
+                <td><button type="button" class="remove-from-pool">-</button></td>
+                <td>${name}</td>
+                <td class="nutrient-col">${data.proteins}</td>
+                <td class="nutrient-col">${data.saturated}</td>
+                <td class="nutrient-col">${data.unsaturated}</td>
+                <td class="nutrient-col">${data.simple}</td>
+                <td class="nutrient-col">${data.complex}</td>
+                <td class="nutrient-col">${data.soluble}</td>
+                <td class="nutrient-col">${data.insoluble}</td>
+                <td class="nutrient-col">${data.kcal}</td>
+                <td><input type="number" class="max-portions" min="0" step="1" value="${defaultMax}"></td>
+                <td><input type="number" class="step" min="0" step="0.1" value="${defaultStep}"></td>
+                <td class="max-weight"><span class="weight-value">0</span></td>
+                <td><input type="checkbox" class="fix-weight"></td>
+                <td><input type="checkbox" class="optimize"></td>
+            `;
+            poolBody.appendChild(tr);
+            updateNutrientVisibility();
+
+            const removeButton = tr.querySelector('.remove-from-pool');
+            const maxPortionsInput = tr.querySelector('.max-portions');
+            const stepInput = tr.querySelector('.step');
+            const weightValue = tr.querySelector('.weight-value');
+            const fixCheckbox = tr.querySelector('.fix-weight');
+            const maxWeightCell = tr.querySelector('.max-weight');
+            const optimizeCheckbox = tr.querySelector('.optimize');
+
+            function updateWeight() {
+                const maxPortions = parseFloat(maxPortionsInput.value) || 0;
+                const step = parseFloat(stepInput.value) || 0;
+                const weight = maxPortions * step;
+                weightValue.textContent = weight.toFixed(1);
+            }
+
+            removeButton.addEventListener('click', function() {
+                removeFromPool(name);
+            });
+
+            maxPortionsInput.addEventListener('input', updateWeight);
+            stepInput.addEventListener('input', updateWeight);
+            updateWeight();
+
+            fixCheckbox.addEventListener('change', function() {
+                maxWeightCell.style.backgroundColor = this.checked ? '#ffb6c1' : '';
+            });
+
+            optimizeCheckbox.addEventListener('change', function() {
+                if (this.checked) {
+                    optimizationList.add(name);
+                } else {
+                    optimizationList.delete(name);
+                }
+            });
         }
 
         function removeFromPool(name) {
@@ -144,27 +154,33 @@
             .then(response => response.text())
             .then(text => {
                 const lines = text.trim().split(/\r?\n/);
-                lines.splice(0, 2); // remove header lines
+                if (!lines.length) {
+                    return;
+                }
+                lines.shift();
                 lines.forEach(line => {
                     if (!line) return;
-                    const cols = line.split(',');
-                    const name = cols[0];
+                    const rawCols = line.split(',');
+                    if (rawCols.length < 9) return;
+                    const cols = rawCols.map(value => value.trim());
+                    const rawName = cols[0] || '';
+                    const name = rawName.replace(/^\ufeff/, '');
+                    if (!name) return;
+
                     products[name] = {
-                        proteins: parseFloat(cols[1]),
-                        saturated: parseFloat(cols[2]),
-                        unsaturated: parseFloat(cols[3]),
-                        simple: parseFloat(cols[4]),
-                        complex: parseFloat(cols[5]),
-                        soluble: parseFloat(cols[6]),
-                        insoluble: parseFloat(cols[7]),
-                        kcal: parseFloat(cols[8]),
-                        defaultMax: parseFloat(cols[9]),
-                        defaultStep: parseFloat(cols[10])
+                        proteins: parseFloat(cols[1]) || 0,
+                        saturated: parseFloat(cols[2]) || 0,
+                        unsaturated: parseFloat(cols[3]) || 0,
+                        simple: parseFloat(cols[4]) || 0,
+                        complex: parseFloat(cols[5]) || 0,
+                        soluble: parseFloat(cols[6]) || 0,
+                        insoluble: parseFloat(cols[7]) || 0,
+                        kcal: parseFloat(cols[8]) || 0
                     };
 
                     const tr = document.createElement('tr');
                     tr.innerHTML = `
-                        <td><input type="checkbox" class="select-product"></td>
+                        <td><button type="button" class="add-product">+</button></td>
                         <td>${name}</td>
                         <td class="nutrient-col">${cols[1]}</td>
                         <td class="nutrient-col">${cols[2]}</td>
@@ -174,19 +190,13 @@
                         <td class="nutrient-col">${cols[6]}</td>
                         <td class="nutrient-col">${cols[7]}</td>
                         <td class="nutrient-col">${cols[8]}</td>
-                        <td>${cols[9]}</td>
-                        <td>${cols[10]}</td>
                     `;
                     dbBody.appendChild(tr);
                     updateNutrientVisibility();
 
-                    const checkbox = tr.querySelector('.select-product');
-                    checkbox.addEventListener('change', function() {
-                        if (this.checked) {
-                            addToPool(name);
-                        } else {
-                            removeFromPool(name);
-                        }
+                    const addButton = tr.querySelector('.add-product');
+                    addButton.addEventListener('click', function() {
+                        addToPool(name);
                     });
                 });
             });


### PR DESCRIPTION
## Summary
- remove the step and max-portion columns from the product database table and replace the selector with an add button
- give new pool entries default step/max values of 10 and manage them with add/remove buttons
- guard against duplicate additions while keeping nutrient toggling in sync

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68c8ab10dfb0832c9c81f9b82b114e21