### PR TITLE
Add OSO calculator modal and backend optimisation workflow

### DIFF
--- a/UI.html
+++ b/UI.html
@@ -45,8 +45,12 @@
             margin-top: 12px;
         }
         #target-summary table,
+        #result-totals table,
         #best-result table {
             width: 100%;
+        }
+        #result-totals {
+            margin-top: 16px;
         }
         #best-result {
             margin-top: 16px;
@@ -290,19 +294,38 @@
     </table>
     <div id="optimization-controls">
         <div class="optimization-field">
-            <label for="residual-share">Доля остатка</label>
-            <input type="number" id="residual-share" min="0" max="1" step="0.05" value="0.5">
+            <label for="residual-share">Доля остатка (%)</label>
+            <input type="number" id="residual-share" min="0" max="100" step="1" value="50">
         </div>
         <div class="optimization-field">
             <label for="run-count">Количество прогонов</label>
             <input type="number" id="run-count" min="1" step="1" value="10">
         </div>
+        <div class="optimization-field">
+            <label>
+                <input type="checkbox" id="allow-zero-weights" checked>
+                Разрешить нулевой вес продуктов
+            </label>
+        </div>
         <button type="button" id="run-optimization">Рассчитать оптимальный рацион</button>
     </div>
     <div id="optimization-results" class="hidden">
         <div class="result-row"><strong>RMSE:</strong> <span id="rmse-result">-</span></div>
-        <div class="result-row"><strong>Доля остатка:</strong> <span id="alpha-result">-</span></div>
+        <div class="result-row"><strong>Доля остатка (%):</strong> <span id="alpha-result">-</span></div>
         <div class="result-row"><strong>Прогон:</strong> <span id="run-result">-</span></div>
+    </div>
+    <div id="result-totals" class="hidden">
+        <h3>Сравнение целевых и расчётных нутриентов</h3>
+        <table>
+            <thead>
+                <tr>
+                    <th>Нутриенты</th>
+                    <th>Целевые</th>
+                    <th>Расчёт</th>
+                </tr>
+            </thead>
+            <tbody id="result-totals-body"></tbody>
+        </table>
     </div>
     <div id="best-result" class="hidden">
         <h3>Продукты с минимальным RMSE</h3>
@@ -384,6 +407,8 @@
             const rmseResult = document.getElementById('rmse-result');
             const alphaResult = document.getElementById('alpha-result');
             const runResult = document.getElementById('run-result');
+            const resultTotalsSection = document.getElementById('result-totals');
+            const resultTotalsBody = document.getElementById('result-totals-body');
             const bestResultSection = document.getElementById('best-result');
             const bestResultBody = document.getElementById('best-result-body');
             const targetSummarySection = document.getElementById('target-summary');
@@ -392,9 +417,19 @@
             const calculatorDialog = document.getElementById('calculator-dialog');
             const calculatorOkButton = document.getElementById('calculator-ok');
             const calculatorCancelButton = document.getElementById('calculator-cancel');
+            const allowZeroWeightsToggle = document.getElementById('allow-zero-weights');
 
             let calculatorSummaryBody = null;
             let updateCalculatorSummary = null;
+
+            function formatValueWithUnit(value, key) {
+                const unit = key === 'calories' ? 'ккал' : 'г';
+                const numeric = Number(value);
+                if (!Number.isFinite(numeric)) {
+                    return '—';
+                }
+                return `${formatNumber(numeric)}&nbsp;${unit}`;
+            }
 
             function resetOptimizationResults() {
                 if (optimizationResults) {
@@ -409,6 +444,7 @@
                 if (runResult) {
                     runResult.textContent = '-';
                 }
+                renderResultTotals(null, null);
                 if (bestResultSection) {
                     bestResultSection.classList.add('hidden');
                 }
@@ -429,12 +465,31 @@
                 const order = ['proteins', 'saturated', 'unsaturated', 'simple', 'complex', 'soluble', 'insoluble', 'calories'];
                 const rows = order.map(key => {
                     const label = SUMMARY_LABELS[key] || key;
-                    const unit = key === 'calories' ? ' ккал' : ' г';
-                    const value = formatNumber(targets[key]);
-                    return `<tr><td>${label}</td><td>${value}${unit}</td></tr>`;
+                    const value = formatValueWithUnit(targets[key], key);
+                    return `<tr><td>${label}</td><td class="right">${value}</td></tr>`;
                 }).join('');
                 targetSummaryBody.innerHTML = rows;
                 targetSummarySection.classList.remove('hidden');
+            }
+
+            function renderResultTotals(targets, totals) {
+                if (!resultTotalsSection || !resultTotalsBody) {
+                    return;
+                }
+                if (!targets || !totals || typeof targets !== 'object' || typeof totals !== 'object') {
+                    resultTotalsSection.classList.add('hidden');
+                    resultTotalsBody.innerHTML = '';
+                    return;
+                }
+                const order = [...NUTRIENT_KEYS, 'calories'];
+                const rows = order.map(key => {
+                    const label = SUMMARY_LABELS[key] || key;
+                    const targetValue = formatValueWithUnit(targets[key], key);
+                    const totalValue = formatValueWithUnit(totals[key], key);
+                    return `<tr><td>${label}</td><td>${targetValue}</td><td>${totalValue}</td></tr>`;
+                }).join('');
+                resultTotalsBody.innerHTML = rows;
+                resultTotalsSection.classList.remove('hidden');
             }
 
             function extractTargetsFromSummary(summaryElement) {
@@ -653,7 +708,7 @@
                 return data;
             }
 
-            function displayOptimizationResult(result, requestedAlpha) {
+            function displayOptimizationResult(result, requestedAlphaFraction) {
                 if (!result) {
                     resetOptimizationResults();
                     return;
@@ -664,13 +719,19 @@
                 if (rmseResult) {
                     rmseResult.textContent = formatNumber(result.rmse ?? 0, 4);
                 }
-                const alphaValue = Number.isFinite(result.residual_share) ? result.residual_share : clampFraction(requestedAlpha);
+                const alphaValue = Number.isFinite(result.residual_share)
+                    ? Number(result.residual_share)
+                    : clampFraction(requestedAlphaFraction);
                 if (alphaResult) {
-                    alphaResult.textContent = formatNumber(alphaValue, 4);
+                    const alphaPercent = alphaValue * 100;
+                    alphaResult.textContent = `${formatNumber(alphaPercent, 2)}%`;
                 }
                 if (runResult) {
                     runResult.textContent = Number.isFinite(result.run) ? result.run.toString() : '-';
                 }
+                const targetsForTotals = (result && typeof result.targets === 'object') ? result.targets : state.currentTargets;
+                const totalsForResult = result && typeof result.totals === 'object' ? result.totals : null;
+                renderResultTotals(targetsForTotals, totalsForResult);
                 if (bestResultBody && bestResultSection) {
                     const weights = Array.isArray(result.weights) ? result.weights.filter(item => Number.isFinite(item.weight) && item.weight > 0) : [];
                     if (weights.length) {
@@ -914,9 +975,9 @@
 
                 if (runOptimizationButton) {
                     runOptimizationButton.addEventListener('click', async () => {
-                        const baseAlpha = parseFloat(residualInput && residualInput.value);
-                        if (!Number.isFinite(baseAlpha) || baseAlpha < 0) {
-                            alert('Введите корректное значение для "Доля остатка".');
+                        const baseAlphaPercent = parseFloat(residualInput && residualInput.value);
+                        if (!Number.isFinite(baseAlphaPercent) || baseAlphaPercent < 0 || baseAlphaPercent > 100) {
+                            alert('Введите корректное значение для "Доля остатка" в процентах.');
                             return;
                         }
                         const runCount = Math.floor(parseFloat(runCountInput && runCountInput.value));
@@ -933,9 +994,12 @@
                             alert('Выберите продукты для оптимизации.');
                             return;
                         }
+                        const allowZeroWeights = allowZeroWeightsToggle ? !!allowZeroWeightsToggle.checked : true;
+                        const alphaFraction = clampFraction(baseAlphaPercent / 100);
                         const payload = {
-                            residual_share: clampFraction(baseAlpha),
+                            residual_share: alphaFraction,
                             run_count: runCount,
+                            allow_zero_weights: allowZeroWeights,
                             targets: state.currentTargets,
                             products: selectedProducts.map(item => ({
                                 name: item.name,
@@ -961,7 +1025,7 @@
                         runOptimizationButton.textContent = 'Расчёт...';
                         try {
                             const result = await requestOptimization(payload);
-                            displayOptimizationResult(result, baseAlpha);
+                            displayOptimizationResult(result, alphaFraction);
                         } catch (error) {
                             console.error(error);
                             alert(error.message || 'Не удалось выполнить оптимизацию.');

--- a/UI.html
+++ b/UI.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <title>Продукты</title>
     <style>
+        .hidden {
+            display: none !important;
+        }
         #db { margin-top: 10px; }
         table { border-collapse: collapse; margin-top: 10px; }
         th, td { border: 1px solid #ccc; padding: 4px; text-align: center; }
@@ -12,6 +15,7 @@
         .max-weight { padding: 2px 4px; }
         .optimized-row { background-color: #ccffcc; }
         .fix-weight-active { background-color: #ffb6c1; }
+        #open-calculator { margin-top: 12px; }
         #optimization-controls {
             margin-top: 12px;
             display: flex;
@@ -37,11 +41,209 @@
         #optimization-results .result-row {
             margin-top: 4px;
         }
+        #target-summary {
+            margin-top: 12px;
+        }
+        #target-summary table,
+        #best-result table {
+            width: 100%;
+        }
+        #best-result {
+            margin-top: 16px;
+        }
+        dialog {
+            border: none;
+            border-radius: 16px;
+            padding: 0;
+            max-width: min(720px, 96vw);
+        }
+        dialog::backdrop {
+            background: rgba(0, 0, 0, 0.35);
+        }
+        #calculatorContainer {
+            font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+        }
+        #calculatorContainer .card {
+            width: min(680px, 96vw);
+            background: #f3f4f6;
+            border: 1px solid #e5e7eb;
+            border-radius: 16px;
+            box-shadow: 0 6px 28px rgba(0,0,0,.08);
+            padding: 18px 16px 18px;
+        }
+        #calculatorContainer .muted { margin: 0 0 10px 0; color: #6b7280; font-size: 13px; }
+        #calculatorContainer .grid { display: grid; gap: 12px; }
+        #calculatorContainer .cols-2 { grid-template-columns: 1fr 1fr; }
+        #calculatorContainer .field {
+            display: grid; gap: 6px;
+            background: #fff; border: 1px solid #e5e7eb; border-radius: 10px; padding: 10px;
+        }
+        #calculatorContainer .field label { font-size: 13px; color: #6b7280; }
+        #calculatorContainer .row { display: grid; grid-template-columns: 1fr auto; gap: 10px; align-items: center; }
+        #calculatorContainer .slider {
+            -webkit-appearance: none; appearance: none; width: 100%; height: 6px;
+            background: linear-gradient(90deg, #0ea5e9, #0ea5e9);
+            background-size: 50% 100%; background-repeat: no-repeat; background-color: #e5e7eb; border-radius: 999px;
+            outline: none;
+        }
+        #calculatorContainer .slider::-webkit-slider-thumb {
+            -webkit-appearance: none; appearance: none; width: 20px; height: 20px; border-radius: 50%; background: #0ea5e9;
+            border: 2px solid #fff; box-shadow: 0 2px 8px rgba(0,0,0,.2);
+        }
+        #calculatorContainer .slider::-moz-range-thumb { width: 20px; height: 20px; border-radius: 50%; background: #0ea5e9; border: 2px solid #fff; }
+        #calculatorContainer .value {
+            min-width: 86px; text-align: right; font-weight: 700; font-size: 18px;
+            padding: 6px 10px; background: #fff; border: 1px solid #e5e7eb; border-radius: 10px;
+        }
+        #calculatorContainer .osso-box {
+            display: grid; grid-template-columns: 1fr auto; gap: 10px; align-items: center;
+            background: #fff; border: 1px solid #e5e7eb; border-radius: 12px; padding: 12px;
+        }
+        #calculatorContainer .osso-title { font-size: 14px; color: #6b7280; margin: 0; }
+        #calculatorContainer .osso-value { font-weight: 800; font-size: 22px; }
+        #calculatorContainer table {
+            width: 100%; border-collapse: collapse; margin-top: 8px; background: #fff; border: 1px solid #e5e7eb; border-radius: 12px; overflow: hidden;
+        }
+        #calculatorContainer th,
+        #calculatorContainer td { padding: 10px 12px; border-bottom: 1px solid #e5e7eb; font-size: 14px; text-align: left; }
+        #calculatorContainer tr:last-child td { border-bottom: none; }
+        #calculatorContainer .buttons { display: none; }
+        #calculator-dialog .modal-actions {
+            display: flex;
+            justify-content: flex-end;
+            gap: 8px;
+            padding: 12px 16px 16px;
+            background: #f9fafb;
+            border-top: 1px solid #e5e7eb;
+            border-bottom-left-radius: 16px;
+            border-bottom-right-radius: 16px;
+        }
+        #calculator-dialog .modal-actions button {
+            padding: 8px 16px;
+            border-radius: 10px;
+            border: 1px solid #d1d5db;
+            background: #0ea5e9;
+            color: #fff;
+            cursor: pointer;
+        }
+        #calculator-dialog .modal-actions button#calculator-cancel {
+            background: #fff;
+            color: #111;
+        }
     </style>
 </head>
 <body>
     <label><input type="checkbox" id="toggle-expanded" checked> Развернутая таблица нутриентов</label>
     <label><input type="checkbox" id="toggle-hide-db"> Скрыть базу данных</label>
+    <button type="button" id="open-calculator">Калькулятор ОСО</button>
+    <section id="target-summary" class="hidden">
+        <h3>Целевые показатели (из калькулятора)</h3>
+        <table>
+            <thead>
+                <tr>
+                    <th>Показатель</th>
+                    <th>Значение</th>
+                </tr>
+            </thead>
+            <tbody id="target-summary-body"></tbody>
+        </table>
+    </section>
+    <dialog id="calculator-dialog">
+        <div id="calculatorContainer" class="tg-theme">
+            <div class="card">
+                <h1>Питательный калькулятор</h1>
+                <p class="muted">Рассчитайте целевые значения нутриентов и калоража. Итоги отображаются в таблице.</p>
+                <section class="grid cols-2" style="margin-top: 6px;">
+                    <div class="field">
+                        <label for="sex">Пол</label>
+                        <select id="sex">
+                            <option value="Мужской">Мужской</option>
+                            <option value="Женский">Женский</option>
+                        </select>
+                    </div>
+                    <div class="field">
+                        <label for="activity">Уровень активности</label>
+                        <select id="activity"></select>
+                    </div>
+                    <div class="field">
+                        <label for="weight">Вес (кг)</label>
+                        <input id="weight" type="number" inputmode="decimal" min="20" max="300" step="0.1" value="67">
+                    </div>
+                    <div class="field">
+                        <label for="height">Рост (см)</label>
+                        <input id="height" type="number" inputmode="decimal" min="100" max="250" step="0.5" value="185">
+                    </div>
+                    <div class="field">
+                        <label for="age">Возраст</label>
+                        <input id="age" type="number" inputmode="numeric" min="10" max="100" step="1" value="26">
+                    </div>
+                    <div class="osso-box">
+                        <div>
+                            <p class="osso-title">Основной суточный обмен (ОСО)</p>
+                            <div id="ossoExplain" class="muted" style="font-size:12px;"></div>
+                        </div>
+                        <div id="osso" class="osso-value">0.0 ккал</div>
+                    </div>
+                </section>
+                <section class="grid" style="margin-top: 14px;">
+                    <div class="row">
+                        <div class="field">
+                            <label>Белки (% от калоража: 20–35)</label>
+                            <input id="pProtein" class="slider" type="range" min="20" max="35" step="1" value="25">
+                        </div>
+                        <div id="vProtein" class="value">25%</div>
+                    </div>
+                    <div class="row">
+                        <div class="field">
+                            <label>Жиры насыщённые (%: 5–10)</label>
+                            <input id="pFatSat" class="slider" type="range" min="5" max="10" step="1" value="8">
+                        </div>
+                        <div id="vFatSat" class="value">8%</div>
+                    </div>
+                    <div class="row">
+                        <div class="field">
+                            <label>Жиры ненасыщённые (%: 12–25)</label>
+                            <input id="pFatUnsat" class="slider" type="range" min="12" max="25" step="1" value="18">
+                        </div>
+                        <div id="vFatUnsat" class="value">18%</div>
+                    </div>
+                    <div class="row">
+                        <div class="field">
+                            <label>Углеводы простые (%: 5–10)</label>
+                            <input id="pCarbSimple" class="slider" type="range" min="5" max="10" step="1" value="7">
+                        </div>
+                        <div id="vCarbSimple" class="value">7%</div>
+                    </div>
+                </section>
+                <section class="grid cols-2" style="margin-top: 14px;">
+                    <div class="field">
+                        <label for="fiberTotal">Общая клетчатка (г)</label>
+                        <input id="fiberTotal" type="number" inputmode="numeric" min="0" max="200" step="1" value="25">
+                    </div>
+                    <div class="field">
+                        <label for="fiberRatio">Соотношение клетчатки (Растворимая : Нерастворимая)</label>
+                        <div class="row">
+                            <input id="fiberRatio" class="slider" type="range" min="2.0" max="3.0" step="0.1" value="2.5">
+                            <div id="vFiberRatio" class="value">1 : 2.5</div>
+                        </div>
+                        <div class="muted">Растворимая — всегда 1; Нерастворимая — ползунок.</div>
+                    </div>
+                </section>
+                <section style="margin-top: 12px;">
+                    <table>
+                        <thead>
+                            <tr><th>Показатель</th><th class="right">Значение</th></tr>
+                        </thead>
+                        <tbody id="summary"></tbody>
+                    </table>
+                </section>
+            </div>
+        </div>
+        <div class="modal-actions">
+            <button type="button" id="calculator-ok">ОК</button>
+            <button type="button" id="calculator-cancel">Отмена</button>
+        </div>
+    </dialog>
     <table id="db">
         <thead>
             <tr>
@@ -50,13 +252,13 @@
                 <th>Белки</th>
                 <th class="collapsed-only">Жиры</th>
                 <th class="collapsed-only">Углеводы</th>
-                <th>ККал</th>
                 <th class="detailed-col">Насыщенные</th>
                 <th class="detailed-col">НЕнасыщенные</th>
                 <th class="detailed-col">Простые</th>
                 <th class="detailed-col">Сложные</th>
                 <th class="detailed-col">Растворимая</th>
                 <th class="detailed-col">Нерастворимая</th>
+                <th>ККал</th>
             </tr>
         </thead>
         <tbody></tbody>
@@ -71,13 +273,13 @@
                 <th>Белки</th>
                 <th class="collapsed-only">Жиры</th>
                 <th class="collapsed-only">Углеводы</th>
-                <th>ККал</th>
                 <th class="detailed-col">Насыщенные</th>
                 <th class="detailed-col">НЕнасыщенные</th>
                 <th class="detailed-col">Простые</th>
                 <th class="detailed-col">Сложные</th>
                 <th class="detailed-col">Растворимая</th>
                 <th class="detailed-col">Нерастворимая</th>
+                <th>ККал</th>
                 <th>Макс. порций</th>
                 <th>Шаг</th>
                 <th>Допустимый вес Max.</th>
@@ -102,397 +304,755 @@
         <div class="result-row"><strong>Доля остатка:</strong> <span id="alpha-result">-</span></div>
         <div class="result-row"><strong>Прогон:</strong> <span id="run-result">-</span></div>
     </div>
+    <div id="best-result" class="hidden">
+        <h3>Продукты с минимальным RMSE</h3>
+        <table>
+            <thead>
+                <tr>
+                    <th>Продукт</th>
+                    <th>Вес (г)</th>
+                </tr>
+            </thead>
+            <tbody id="best-result-body"></tbody>
+        </table>
+    </div>
 
-    <script>
-        const dbTable = document.getElementById('db');
-        const dbBody = dbTable.querySelector('tbody');
-        const poolTable = document.getElementById('pool');
-        const poolBody = poolTable.querySelector('tbody');
-        const products = {};
-        const optimizationList = new Set();
-        const expandedToggle = document.getElementById('toggle-expanded');
-        const hideDbToggle = document.getElementById('toggle-hide-db');
-        const residualInput = document.getElementById('residual-share');
-        const runCountInput = document.getElementById('run-count');
-        const runOptimizationButton = document.getElementById('run-optimization');
-        const optimizationResults = document.getElementById('optimization-results');
-        const rmseResult = document.getElementById('rmse-result');
-        const alphaResult = document.getElementById('alpha-result');
-        const runResult = document.getElementById('run-result');
-        const NUTRIENT_KEYS = ['proteins', 'saturated', 'unsaturated', 'simple', 'complex', 'soluble', 'insoluble'];
+        <script>
+        (function() {
+            'use strict';
 
-        function formatNumber(value) {
-            return Number.isFinite(value) ? parseFloat(value.toFixed(2)).toString() : '0';
-        }
-
-        function clampFraction(value) {
-            if (!Number.isFinite(value)) {
-                return 0;
-            }
-            if (value < 0) {
-                return 0;
-            }
-            if (value > 1) {
-                return 1;
-            }
-            return value;
-        }
-
-        function resetOptimizationResults() {
-            optimizationResults.classList.add('hidden');
-            rmseResult.textContent = '-';
-            alphaResult.textContent = '-';
-            runResult.textContent = '-';
-        }
-
-        function computeRmseFromTotals(totals, target) {
-            const diffs = [];
-            NUTRIENT_KEYS.forEach(key => {
-                const totalValue = totals[key] || 0;
-                const targetValue = target[key] || 0;
-                diffs.push(totalValue - targetValue);
-            });
-            const totalCalories = totals.calories || 0;
-            const targetCalories = target.calories || 0;
-            diffs.push(totalCalories - targetCalories);
-            if (!diffs.length) {
-                return 0;
-            }
-            const sumSquares = diffs.reduce((acc, value) => acc + value * value, 0);
-            return Math.sqrt(sumSquares / diffs.length);
-        }
-
-        function gatherOptimizationProducts() {
-            const selected = [];
-            poolBody.querySelectorAll('tr').forEach(row => {
-                const optimizeCheckbox = row.querySelector('.optimize');
-                if (!optimizeCheckbox || !optimizeCheckbox.checked) {
-                    return;
-                }
-                const name = row.getAttribute('data-name');
-                if (!name || !products[name]) {
-                    return;
-                }
-                const stepInput = row.querySelector('.step');
-                const maxPortionsInput = row.querySelector('.max-portions');
-                const fixCheckbox = row.querySelector('.fix-weight');
-                const stepValue = parseFloat(stepInput && stepInput.value) || 0;
-                const maxPortionsValue = parseFloat(maxPortionsInput && maxPortionsInput.value) || 0;
-                const maxWeight = stepValue * maxPortionsValue;
-                selected.push({
-                    name,
-                    maxWeight,
-                    fixWeight: Boolean(fixCheckbox && fixCheckbox.checked),
-                    nutrients: {
-                        proteins: products[name].proteins || 0,
-                        saturated: products[name].saturated || 0,
-                        unsaturated: products[name].unsaturated || 0,
-                        simple: products[name].simple || 0,
-                        complex: products[name].complex || 0,
-                        soluble: products[name].soluble || 0,
-                        insoluble: products[name].insoluble || 0,
-                        kcal: products[name].kcal || 0
-                    }
-                });
-            });
-            return selected;
-        }
-
-        function runDietOptimization(selectedProducts, baseAlpha, runCount) {
-            if (!selectedProducts.length || runCount <= 0) {
-                return null;
-            }
-            const alphaClamped = clampFraction(baseAlpha);
-            const maxTotals = {};
-            NUTRIENT_KEYS.forEach(key => {
-                maxTotals[key] = 0;
-            });
-            maxTotals.calories = 0;
-            selectedProducts.forEach(item => {
-                const weightFactor = (item.maxWeight || 0) / 100;
-                NUTRIENT_KEYS.forEach(key => {
-                    const nutrientValue = item.nutrients[key] || 0;
-                    maxTotals[key] += nutrientValue * weightFactor;
-                });
-                maxTotals.calories += (item.nutrients.kcal || 0) * weightFactor;
-            });
-            let bestResult = {
-                rmse: Number.POSITIVE_INFINITY,
-                run: 0,
-                alpha: 0,
-                totals: null
+            const NUTRIENT_KEYS = ['proteins', 'saturated', 'unsaturated', 'simple', 'complex', 'soluble', 'insoluble'];
+            const SUMMARY_LABELS = {
+                proteins: 'Белки',
+                saturated: 'Жиры насыщенные',
+                unsaturated: 'Жиры ненасыщенные',
+                simple: 'Углеводы простые',
+                complex: 'Углеводы сложные перевариваемые',
+                soluble: 'Клетчатка растворимая',
+                insoluble: 'Клетчатка нерастворимая',
+                calories: 'ККал'
             };
-            const iterations = Math.max(1, runCount);
-            for (let index = 0; index < iterations; index += 1) {
-                const iterationNumber = index + 1;
-                const alphaCandidate = iterations > 1
-                    ? alphaClamped * (iterationNumber / iterations)
-                    : alphaClamped;
-                const target = {};
-                NUTRIENT_KEYS.forEach(key => {
-                    target[key] = maxTotals[key] * alphaCandidate;
+            const SUMMARY_NAME_MAP = new Map([
+                ['Белки', 'proteins'],
+                ['Жиры насыщенные', 'saturated'],
+                ['Жиры ненасыщенные', 'unsaturated'],
+                ['Углеводы простые', 'simple'],
+                ['Углеводы сложные перевариваемые', 'complex'],
+                ['Клетчатка растворимая', 'soluble'],
+                ['Клетчатка нерастворимая', 'insoluble'],
+                ['ККал', 'calories']
+            ]);
+            const API_ENDPOINT = 'api/optimize';
+
+            const state = {
+                products: {},
+                optimizationList: new Set(),
+                currentTargets: null
+            };
+
+            function formatNumber(value, fractionDigits = 2) {
+                const number = Number(value);
+                if (!Number.isFinite(number)) {
+                    return '0';
+                }
+                return parseFloat(number.toFixed(fractionDigits)).toString();
+            }
+
+            function clampFraction(value) {
+                if (!Number.isFinite(value)) {
+                    return 0;
+                }
+                if (value < 0) {
+                    return 0;
+                }
+                if (value > 1) {
+                    return 1;
+                }
+                return value;
+            }
+
+            const dbTable = document.getElementById('db');
+            const dbBody = dbTable ? dbTable.querySelector('tbody') : null;
+            const poolTable = document.getElementById('pool');
+            const poolBody = poolTable ? poolTable.querySelector('tbody') : null;
+            const expandedToggle = document.getElementById('toggle-expanded');
+            const hideDbToggle = document.getElementById('toggle-hide-db');
+            const residualInput = document.getElementById('residual-share');
+            const runCountInput = document.getElementById('run-count');
+            const runOptimizationButton = document.getElementById('run-optimization');
+            const optimizationResults = document.getElementById('optimization-results');
+            const rmseResult = document.getElementById('rmse-result');
+            const alphaResult = document.getElementById('alpha-result');
+            const runResult = document.getElementById('run-result');
+            const bestResultSection = document.getElementById('best-result');
+            const bestResultBody = document.getElementById('best-result-body');
+            const targetSummarySection = document.getElementById('target-summary');
+            const targetSummaryBody = document.getElementById('target-summary-body');
+            const openCalculatorButton = document.getElementById('open-calculator');
+            const calculatorDialog = document.getElementById('calculator-dialog');
+            const calculatorOkButton = document.getElementById('calculator-ok');
+            const calculatorCancelButton = document.getElementById('calculator-cancel');
+
+            let calculatorSummaryBody = null;
+            let updateCalculatorSummary = null;
+
+            function resetOptimizationResults() {
+                if (optimizationResults) {
+                    optimizationResults.classList.add('hidden');
+                }
+                if (rmseResult) {
+                    rmseResult.textContent = '-';
+                }
+                if (alphaResult) {
+                    alphaResult.textContent = '-';
+                }
+                if (runResult) {
+                    runResult.textContent = '-';
+                }
+                if (bestResultSection) {
+                    bestResultSection.classList.add('hidden');
+                }
+                if (bestResultBody) {
+                    bestResultBody.innerHTML = '';
+                }
+            }
+
+            function renderTargetSummary(targets) {
+                if (!targetSummarySection || !targetSummaryBody) {
+                    return;
+                }
+                if (!targets) {
+                    targetSummarySection.classList.add('hidden');
+                    targetSummaryBody.innerHTML = '';
+                    return;
+                }
+                const order = ['proteins', 'saturated', 'unsaturated', 'simple', 'complex', 'soluble', 'insoluble', 'calories'];
+                const rows = order.map(key => {
+                    const label = SUMMARY_LABELS[key] || key;
+                    const unit = key === 'calories' ? ' ккал' : ' г';
+                    const value = formatNumber(targets[key]);
+                    return `<tr><td>${label}</td><td>${value}${unit}</td></tr>`;
+                }).join('');
+                targetSummaryBody.innerHTML = rows;
+                targetSummarySection.classList.remove('hidden');
+            }
+
+            function extractTargetsFromSummary(summaryElement) {
+                if (!summaryElement) {
+                    return null;
+                }
+                const values = {};
+                SUMMARY_NAME_MAP.forEach((key) => {
+                    values[key] = null;
                 });
-                target.calories = maxTotals.calories * alphaCandidate;
-                const totals = {};
-                NUTRIENT_KEYS.forEach(key => {
-                    totals[key] = 0;
-                });
-                totals.calories = 0;
-                selectedProducts.forEach(item => {
-                    const maxWeight = item.maxWeight || 0;
-                    if (maxWeight <= 0) {
+                summaryElement.querySelectorAll('tr').forEach(row => {
+                    const cells = row.querySelectorAll('td');
+                    if (cells.length !== 2) {
                         return;
                     }
-                    const fraction = item.fixWeight ? alphaCandidate : Math.random() * alphaCandidate;
-                    const weight = maxWeight * fraction;
-                    const portionFactor = weight / 100;
-                    NUTRIENT_KEYS.forEach(key => {
-                        const nutrientValue = item.nutrients[key] || 0;
-                        totals[key] += nutrientValue * portionFactor;
-                    });
-                    totals.calories += (item.nutrients.kcal || 0) * portionFactor;
+                    const name = cells[0].textContent.trim();
+                    const key = SUMMARY_NAME_MAP.get(name);
+                    if (!key) {
+                        return;
+                    }
+                    const numeric = parseFloat(cells[1].textContent.replace(/[^0-9.,-]/g, '').replace(',', '.'));
+                    if (Number.isFinite(numeric)) {
+                        values[key] = numeric;
+                    }
                 });
-                const rmse = computeRmseFromTotals(totals, target);
-                if (rmse < bestResult.rmse) {
-                    bestResult = {
-                        rmse,
-                        run: iterationNumber,
-                        alpha: alphaCandidate,
-                        totals
-                    };
-                }
-            }
-            if (!Number.isFinite(bestResult.rmse)) {
-                bestResult.rmse = 0;
-            }
-            return bestResult;
-        }
-
-        function displayOptimizationResult(result) {
-            if (!result) {
-                resetOptimizationResults();
-                return;
-            }
-            rmseResult.textContent = result.rmse.toFixed(4);
-            alphaResult.textContent = result.alpha.toFixed(4);
-            runResult.textContent = result.run.toString();
-            optimizationResults.classList.remove('hidden');
-        }
-
-        function updateNutrientVisibility() {
-            const expanded = expandedToggle.checked;
-            document.querySelectorAll('.detailed-col').forEach(cell => {
-                cell.style.display = expanded ? 'table-cell' : 'none';
-            });
-            document.querySelectorAll('.collapsed-only').forEach(cell => {
-                cell.style.display = expanded ? 'none' : 'table-cell';
-            });
-        }
-
-        function updateDbVisibility() {
-            dbTable.style.display = hideDbToggle.checked ? 'none' : 'table';
-        }
-
-        expandedToggle.addEventListener('change', updateNutrientVisibility);
-        hideDbToggle.addEventListener('change', updateDbVisibility);
-
-        updateNutrientVisibility();
-        updateDbVisibility();
-
-        function addToPool(name) {
-            const existing = document.querySelector('#pool tbody tr[data-name="' + name + '"]');
-            if (existing) {
-                alert('Продукт уже в пуле');
-                return;
+                const result = {};
+                let hasValid = false;
+                SUMMARY_NAME_MAP.forEach((key) => {
+                    const value = values[key];
+                    if (Number.isFinite(value)) {
+                        result[key] = value;
+                        hasValid = true;
+                    }
+                });
+                return hasValid ? result : null;
             }
 
-            const data = products[name] || {};
-            const defaultMax = 10;
-            const defaultStep = 10;
-            const tr = document.createElement('tr');
-            tr.setAttribute('data-name', name);
-            const proteinsDisplay = formatNumber(data.proteins || 0);
-            const fatsDisplay = formatNumber(data.fats || 0);
-            const carbsDisplay = formatNumber(data.carbs || 0);
-            const kcalDisplay = formatNumber(data.kcal || 0);
-            const saturatedDisplay = formatNumber(data.saturated || 0);
-            const unsaturatedDisplay = formatNumber(data.unsaturated || 0);
-            const simpleDisplay = formatNumber(data.simple || 0);
-            const complexDisplay = formatNumber(data.complex || 0);
-            const solubleDisplay = formatNumber(data.soluble || 0);
-            const insolubleDisplay = formatNumber(data.insoluble || 0);
-
-            tr.innerHTML = `
-                <td><button type="button" class="remove-from-pool">-</button></td>
-                <td><input type="checkbox" class="optimize"></td>
-                <td>${name}</td>
-                <td>${proteinsDisplay}</td>
-                <td class="collapsed-only">${fatsDisplay}</td>
-                <td class="collapsed-only">${carbsDisplay}</td>
-                <td>${kcalDisplay}</td>
-                <td class="detailed-col">${saturatedDisplay}</td>
-                <td class="detailed-col">${unsaturatedDisplay}</td>
-                <td class="detailed-col">${simpleDisplay}</td>
-                <td class="detailed-col">${complexDisplay}</td>
-                <td class="detailed-col">${solubleDisplay}</td>
-                <td class="detailed-col">${insolubleDisplay}</td>
-                <td><input type="number" class="max-portions" min="0" step="1" value="${defaultMax}"></td>
-                <td><input type="number" class="step" min="0" step="0.1" value="${defaultStep}"></td>
-                <td class="max-weight"><span class="weight-value">0</span></td>
-                <td class="fix-weight-cell"><input type="checkbox" class="fix-weight"></td>
-            `;
-            poolBody.appendChild(tr);
-            updateNutrientVisibility();
-
-            const removeButton = tr.querySelector('.remove-from-pool');
-            const maxPortionsInput = tr.querySelector('.max-portions');
-            const stepInput = tr.querySelector('.step');
-            const weightValue = tr.querySelector('.weight-value');
-            const fixCheckbox = tr.querySelector('.fix-weight');
-            const fixWeightCell = tr.querySelector('.fix-weight-cell');
-            const maxWeightCell = tr.querySelector('.max-weight');
-            const optimizeCheckbox = tr.querySelector('.optimize');
-
-            function updateWeight() {
-                const maxPortions = parseFloat(maxPortionsInput.value) || 0;
-                const step = parseFloat(stepInput.value) || 0;
-                const weight = maxPortions * step;
-                weightValue.textContent = weight.toFixed(1);
-                resetOptimizationResults();
+            function updateNutrientVisibility() {
+                const expanded = expandedToggle ? expandedToggle.checked : true;
+                document.querySelectorAll('.detailed-col').forEach(cell => {
+                    cell.style.display = expanded ? 'table-cell' : 'none';
+                });
+                document.querySelectorAll('.collapsed-only').forEach(cell => {
+                    cell.style.display = expanded ? 'none' : 'table-cell';
+                });
             }
 
-            removeButton.addEventListener('click', function() {
-                removeFromPool(name);
-            });
-
-            maxPortionsInput.addEventListener('input', updateWeight);
-            stepInput.addEventListener('input', updateWeight);
-            updateWeight();
-
-            function updateFixWeightStyles() {
-                if (fixCheckbox.checked) {
-                    maxWeightCell.classList.add('fix-weight-active');
-                    fixWeightCell.classList.add('fix-weight-active');
-                } else {
-                    maxWeightCell.classList.remove('fix-weight-active');
-                    fixWeightCell.classList.remove('fix-weight-active');
-                }
-                resetOptimizationResults();
-            }
-
-            fixCheckbox.addEventListener('change', updateFixWeightStyles);
-            updateFixWeightStyles();
-
-            function updateOptimizeState() {
-                if (optimizeCheckbox.checked) {
-                    optimizationList.add(name);
-                    tr.classList.add('optimized-row');
-                } else {
-                    optimizationList.delete(name);
-                    tr.classList.remove('optimized-row');
-                }
-                resetOptimizationResults();
-            }
-
-            optimizeCheckbox.addEventListener('change', updateOptimizeState);
-            updateOptimizeState();
-        }
-
-        function removeFromPool(name) {
-            const tr = document.querySelector('#pool tbody tr[data-name="' + name + '"]');
-            if (tr) {
-                tr.remove();
-            }
-            optimizationList.delete(name);
-            resetOptimizationResults();
-        }
-
-        runOptimizationButton.addEventListener('click', () => {
-            const baseAlpha = parseFloat(residualInput.value);
-            if (!Number.isFinite(baseAlpha) || baseAlpha < 0) {
-                alert('Введите корректное значение для "Доля остатка".');
-                return;
-            }
-            const runCount = Math.floor(parseFloat(runCountInput.value));
-            if (!Number.isFinite(runCount) || runCount <= 0) {
-                alert('Количество прогонов должно быть положительным целым числом.');
-                return;
-            }
-            const selectedProducts = gatherOptimizationProducts();
-            if (!selectedProducts.length) {
-                alert('Выберите продукты для оптимизации.');
-                return;
-            }
-            const result = runDietOptimization(selectedProducts, baseAlpha, runCount);
-            displayOptimizationResult(result);
-        });
-
-        fetch('Nutrients%20DB.csv')
-            .then(response => response.text())
-            .then(text => {
-                const lines = text.trim().split(/\r?\n/);
-                if (!lines.length) {
+            function updateDbVisibility() {
+                if (!dbTable) {
                     return;
                 }
-                lines.shift();
-                lines.forEach(line => {
-                    if (!line) return;
-                    const rawCols = line.split(',');
-                    if (rawCols.length < 9) return;
-                    const cols = rawCols.map(value => value.trim());
-                    const rawName = cols[0] || '';
-                    const name = rawName.replace(/^\ufeff/, '');
-                    if (!name) return;
+                dbTable.style.display = hideDbToggle && hideDbToggle.checked ? 'none' : 'table';
+            }
 
-                    const proteins = parseFloat(cols[1]) || 0;
-                    const saturated = parseFloat(cols[2]) || 0;
-                    const unsaturated = parseFloat(cols[3]) || 0;
-                    const simple = parseFloat(cols[4]) || 0;
-                    const complex = parseFloat(cols[5]) || 0;
-                    const soluble = parseFloat(cols[6]) || 0;
-                    const insoluble = parseFloat(cols[7]) || 0;
-                    const kcal = parseFloat(cols[8]) || 0;
-                    const fats = saturated + unsaturated;
-                    const carbs = simple + complex + soluble + insoluble;
-
-                    products[name] = {
-                        proteins,
-                        saturated,
-                        unsaturated,
-                        simple,
-                        complex,
-                        soluble,
-                        insoluble,
-                        kcal,
-                        fats,
-                        carbs
-                    };
-
-                    const tr = document.createElement('tr');
-                    tr.innerHTML = `
-                        <td><button type="button" class="add-product">+</button></td>
-                        <td>${name}</td>
-                        <td>${formatNumber(proteins)}</td>
-                        <td class="collapsed-only">${formatNumber(fats)}</td>
-                        <td class="collapsed-only">${formatNumber(carbs)}</td>
-                        <td>${formatNumber(kcal)}</td>
-                        <td class="detailed-col">${formatNumber(saturated)}</td>
-                        <td class="detailed-col">${formatNumber(unsaturated)}</td>
-                        <td class="detailed-col">${formatNumber(simple)}</td>
-                        <td class="detailed-col">${formatNumber(complex)}</td>
-                        <td class="detailed-col">${formatNumber(soluble)}</td>
-                        <td class="detailed-col">${formatNumber(insoluble)}</td>
-                    `;
-                    dbBody.appendChild(tr);
-                    updateNutrientVisibility();
-
-                    const addButton = tr.querySelector('.add-product');
-                    addButton.addEventListener('click', function() {
-                        addToPool(name);
+            function gatherOptimizationProducts() {
+                if (!poolBody) {
+                    return [];
+                }
+                const selected = [];
+                poolBody.querySelectorAll('tr').forEach(row => {
+                    const optimizeCheckbox = row.querySelector('.optimize');
+                    if (!optimizeCheckbox || !optimizeCheckbox.checked) {
+                        return;
+                    }
+                    const name = row.getAttribute('data-name');
+                    if (!name || !state.products[name]) {
+                        return;
+                    }
+                    const stepInput = row.querySelector('.step');
+                    const maxPortionsInput = row.querySelector('.max-portions');
+                    const fixCheckbox = row.querySelector('.fix-weight');
+                    const stepValue = parseFloat(stepInput && stepInput.value) || 0;
+                    const maxPortionsValue = parseFloat(maxPortionsInput && maxPortionsInput.value) || 0;
+                    const maxWeight = stepValue * maxPortionsValue;
+                    const fixedWeight = fixCheckbox && fixCheckbox.checked ? maxWeight : 0;
+                    selected.push({
+                        name,
+                        step: stepValue,
+                        max_weight: maxWeight,
+                        fix_weight: Boolean(fixCheckbox && fixCheckbox.checked),
+                        fixed_weight: fixedWeight,
+                        nutrients: state.products[name]
                     });
                 });
-            });
+                return selected;
+            }
 
+            function addToPool(name) {
+                if (!poolBody) {
+                    return;
+                }
+                const existing = document.querySelector(`#pool tbody tr[data-name="${name}"]`);
+                if (existing) {
+                    alert('Продукт уже в пуле');
+                    return;
+                }
+                const data = state.products[name] || {};
+                const defaultMax = 10;
+                const defaultStep = 10;
+                const tr = document.createElement('tr');
+                tr.setAttribute('data-name', name);
+                const proteinsDisplay = formatNumber(data.proteins || 0);
+                const fatsDisplay = formatNumber(data.fats || 0);
+                const carbsDisplay = formatNumber(data.carbs || 0);
+                const kcalDisplay = formatNumber(data.kcal || 0);
+                const saturatedDisplay = formatNumber(data.saturated || 0);
+                const unsaturatedDisplay = formatNumber(data.unsaturated || 0);
+                const simpleDisplay = formatNumber(data.simple || 0);
+                const complexDisplay = formatNumber(data.complex || 0);
+                const solubleDisplay = formatNumber(data.soluble || 0);
+                const insolubleDisplay = formatNumber(data.insoluble || 0);
+
+                tr.innerHTML = `
+                    <td><button type="button" class="remove-from-pool">-</button></td>
+                    <td><input type="checkbox" class="optimize"></td>
+                    <td>${name}</td>
+                    <td>${proteinsDisplay}</td>
+                    <td class="collapsed-only">${fatsDisplay}</td>
+                    <td class="collapsed-only">${carbsDisplay}</td>
+                    <td class="detailed-col">${saturatedDisplay}</td>
+                    <td class="detailed-col">${unsaturatedDisplay}</td>
+                    <td class="detailed-col">${simpleDisplay}</td>
+                    <td class="detailed-col">${complexDisplay}</td>
+                    <td class="detailed-col">${solubleDisplay}</td>
+                    <td class="detailed-col">${insolubleDisplay}</td>
+                    <td>${kcalDisplay}</td>
+                    <td><input type="number" class="max-portions" min="0" step="1" value="${defaultMax}"></td>
+                    <td><input type="number" class="step" min="0" step="0.1" value="${defaultStep}"></td>
+                    <td class="max-weight"><span class="weight-value">0</span></td>
+                    <td class="fix-weight-cell"><input type="checkbox" class="fix-weight"></td>
+                `;
+                poolBody.appendChild(tr);
+                updateNutrientVisibility();
+
+                const removeButton = tr.querySelector('.remove-from-pool');
+                const maxPortionsInput = tr.querySelector('.max-portions');
+                const stepInput = tr.querySelector('.step');
+                const weightValue = tr.querySelector('.weight-value');
+                const fixCheckbox = tr.querySelector('.fix-weight');
+                const fixWeightCell = tr.querySelector('.fix-weight-cell');
+                const maxWeightCell = tr.querySelector('.max-weight');
+                const optimizeCheckbox = tr.querySelector('.optimize');
+
+                function updateWeight() {
+                    const maxPortions = parseFloat(maxPortionsInput.value) || 0;
+                    const step = parseFloat(stepInput.value) || 0;
+                    const weight = maxPortions * step;
+                    weightValue.textContent = (Math.round(weight * 10) / 10).toFixed(1);
+                    resetOptimizationResults();
+                }
+
+                removeButton.addEventListener('click', () => {
+                    removeFromPool(name);
+                });
+
+                maxPortionsInput.addEventListener('input', updateWeight);
+                stepInput.addEventListener('input', updateWeight);
+                updateWeight();
+
+                function updateFixWeightStyles() {
+                    if (fixCheckbox.checked) {
+                        maxWeightCell.classList.add('fix-weight-active');
+                        fixWeightCell.classList.add('fix-weight-active');
+                    } else {
+                        maxWeightCell.classList.remove('fix-weight-active');
+                        fixWeightCell.classList.remove('fix-weight-active');
+                    }
+                    resetOptimizationResults();
+                }
+
+                fixCheckbox.addEventListener('change', updateFixWeightStyles);
+                updateFixWeightStyles();
+
+                function updateOptimizeState() {
+                    if (optimizeCheckbox.checked) {
+                        state.optimizationList.add(name);
+                        tr.classList.add('optimized-row');
+                    } else {
+                        state.optimizationList.delete(name);
+                        tr.classList.remove('optimized-row');
+                    }
+                    resetOptimizationResults();
+                }
+
+                optimizeCheckbox.addEventListener('change', updateOptimizeState);
+                updateOptimizeState();
+            }
+
+            function removeFromPool(name) {
+                const row = document.querySelector(`#pool tbody tr[data-name="${name}"]`);
+                if (row) {
+                    row.remove();
+                }
+                state.optimizationList.delete(name);
+                resetOptimizationResults();
+            }
+
+            async function requestOptimization(payload) {
+                const response = await fetch(API_ENDPOINT, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify(payload)
+                });
+                let data = null;
+                try {
+                    data = await response.json();
+                } catch (error) {
+                    data = null;
+                }
+                if (!response.ok) {
+                    const message = data && data.error ? data.error : 'Ошибка при расчёте рациона.';
+                    throw new Error(message);
+                }
+                return data;
+            }
+
+            function displayOptimizationResult(result, requestedAlpha) {
+                if (!result) {
+                    resetOptimizationResults();
+                    return;
+                }
+                if (optimizationResults) {
+                    optimizationResults.classList.remove('hidden');
+                }
+                if (rmseResult) {
+                    rmseResult.textContent = formatNumber(result.rmse ?? 0, 4);
+                }
+                const alphaValue = Number.isFinite(result.residual_share) ? result.residual_share : clampFraction(requestedAlpha);
+                if (alphaResult) {
+                    alphaResult.textContent = formatNumber(alphaValue, 4);
+                }
+                if (runResult) {
+                    runResult.textContent = Number.isFinite(result.run) ? result.run.toString() : '-';
+                }
+                if (bestResultBody && bestResultSection) {
+                    const weights = Array.isArray(result.weights) ? result.weights.filter(item => Number.isFinite(item.weight) && item.weight > 0) : [];
+                    if (weights.length) {
+                        weights.sort((a, b) => b.weight - a.weight);
+                        bestResultBody.innerHTML = weights.map(item => `<tr><td>${item.name}</td><td>${formatNumber(item.weight)}</td></tr>`).join('');
+                    } else {
+                        bestResultBody.innerHTML = '<tr><td colspan="2">Данные отсутствуют</td></tr>';
+                    }
+                    bestResultSection.classList.remove('hidden');
+                }
+            }
+
+            function hasValidTargets(targets) {
+                if (!targets) {
+                    return false;
+                }
+                const requiredKeys = ['proteins', 'saturated', 'unsaturated', 'simple', 'complex', 'soluble', 'insoluble', 'calories'];
+                return requiredKeys.every(key => Number.isFinite(Number(targets[key])));
+            }
+
+            function setupCalculator() {
+                if (!calculatorDialog) {
+                    return;
+                }
+                const container = calculatorDialog.querySelector('#calculatorContainer');
+                if (!container) {
+                    return;
+                }
+                const SEX_ADD = {
+                    'Мужской': 1,
+                    'Женский': -161
+                };
+                const ACTIVITY = [
+                    ['Минимальный (сидячий образ жизни)', 1.2],
+                    ['Низкий (легкие тренировки 1–3 раза в неделю)', 1.375],
+                    ['Умеренный (тренировки 3–5 раз в неделю)', 1.55],
+                    ['Высокий (интенсивные тренировки 6–7 раз в неделю)', 1.725],
+                    ['Экстремальный (профессиональные атлеты, тяжелый физический труд)', 1.9]
+                ];
+
+                const elSex = container.querySelector('#sex');
+                const elAct = container.querySelector('#activity');
+                const elW = container.querySelector('#weight');
+                const elH = container.querySelector('#height');
+                const elA = container.querySelector('#age');
+                const elOSO = container.querySelector('#osso');
+                const elOSOExplain = container.querySelector('#ossoExplain');
+                const elpProt = container.querySelector('#pProtein');
+                const elpSat = container.querySelector('#pFatSat');
+                const elpUns = container.querySelector('#pFatUnsat');
+                const elpSim = container.querySelector('#pCarbSimple');
+                const elvProt = container.querySelector('#vProtein');
+                const elvSat = container.querySelector('#vFatSat');
+                const elvUns = container.querySelector('#vFatUnsat');
+                const elvSim = container.querySelector('#vCarbSimple');
+                const elFibTotal = container.querySelector('#fiberTotal');
+                const elFibRatio = container.querySelector('#fiberRatio');
+                const elvFibRatio = container.querySelector('#vFiberRatio');
+                calculatorSummaryBody = container.querySelector('#summary');
+
+                function fillActivity() {
+                    if (!elAct) {
+                        return;
+                    }
+                    elAct.innerHTML = '';
+                    ACTIVITY.forEach(([label]) => {
+                        const option = document.createElement('option');
+                        option.value = label;
+                        option.textContent = label;
+                        elAct.appendChild(option);
+                    });
+                    elAct.value = 'Низкий (легкие тренировки 1–3 раза в неделю)';
+                }
+
+                function setGradient(range) {
+                    if (!range) {
+                        return;
+                    }
+                    const min = parseFloat(range.min);
+                    const max = parseFloat(range.max);
+                    const value = parseFloat(range.value);
+                    if (!Number.isFinite(min) || !Number.isFinite(max) || !Number.isFinite(value)) {
+                        return;
+                    }
+                    const pct = ((value - min) / (max - min)) * 100;
+                    range.style.backgroundSize = `${pct}% 100%`;
+                }
+
+                function calcOSO(weightKg, heightCm, ageYears, sex, activityLabel) {
+                    const sexAdd = SEX_ADD[sex] ?? -161;
+                    const activityRow = ACTIVITY.find(([label]) => label === activityLabel);
+                    const activityMultiplier = activityRow ? activityRow[1] : 1;
+                    const base = (10 * weightKg) + (6.25 * heightCm) - (5 * ageYears) + sexAdd;
+                    return base * activityMultiplier;
+                }
+
+                function clampValue(value, min, max) {
+                    return Math.min(max, Math.max(min, value));
+                }
+
+                function readNumber(input, fallback = 0) {
+                    if (!input) {
+                        return fallback;
+                    }
+                    const parsed = parseFloat(String(input.value || '').replace(',', '.'));
+                    return Number.isFinite(parsed) ? parsed : fallback;
+                }
+
+                function syncUIBits() {
+                    if (elvProt && elpProt) {
+                        elvProt.textContent = `${elpProt.value}%`;
+                    }
+                    if (elvSat && elpSat) {
+                        elvSat.textContent = `${elpSat.value}%`;
+                    }
+                    if (elvUns && elpUns) {
+                        elvUns.textContent = `${elpUns.value}%`;
+                    }
+                    if (elvSim && elpSim) {
+                        elvSim.textContent = `${elpSim.value}%`;
+                    }
+                    if (elvFibRatio && elFibRatio) {
+                        elvFibRatio.textContent = `1 : ${parseFloat(elFibRatio.value).toFixed(1)}`;
+                    }
+                    [elpProt, elpSat, elpUns, elpSim, elFibRatio].forEach(setGradient);
+                }
+
+                function updateSummary() {
+                    syncUIBits();
+                    if (!calculatorSummaryBody) {
+                        return;
+                    }
+                    const sex = elSex ? elSex.value : 'Мужской';
+                    const activity = elAct ? elAct.value : ACTIVITY[1][0];
+                    const weight = clampValue(readNumber(elW, 0), 0, 999);
+                    const height = clampValue(readNumber(elH, 0), 0, 999);
+                    const age = clampValue(readNumber(elA, 0), 0, 150);
+
+                    const oso = calcOSO(weight, height, age, sex, activity);
+                    if (elOSO) {
+                        elOSO.textContent = `${(Math.round(oso * 10) / 10).toFixed(1)} ккал`;
+                    }
+                    if (elOSOExplain) {
+                        const actMultiplier = ACTIVITY.find(([label]) => label === activity)?.[1] || 1;
+                        elOSOExplain.textContent = `((10×${weight}) + (6.25×${height}) − (5×${age}) + ${SEX_ADD[sex] ?? -161}) × ${actMultiplier}`;
+                    }
+
+                    const pProt = elpProt ? parseInt(elpProt.value, 10) / 100 : 0.25;
+                    const pSat = elpSat ? parseInt(elpSat.value, 10) / 100 : 0.08;
+                    const pUns = elpUns ? parseInt(elpUns.value, 10) / 100 : 0.18;
+                    const pSim = elpSim ? parseInt(elpSim.value, 10) / 100 : 0.07;
+
+                    const gProt = Math.round((oso * pProt) / 4);
+                    const gSat = Math.round((oso * pSat) / 9);
+                    const gUns = Math.round((oso * pUns) / 9);
+                    const gSim = Math.round((oso * pSim) / 4);
+
+                    const fibTotal = Math.round(clampValue(readNumber(elFibTotal, 0), 0, 999));
+                    const ratio = parseFloat(elFibRatio ? elFibRatio.value : '2.5');
+                    const gFibSol = Math.round(fibTotal / (1 + ratio));
+                    const gFibIns = Math.round(fibTotal - gFibSol);
+
+                    const kcalUsed = (gProt * 4) + (gSat * 9) + (gUns * 9) + (gSim * 4) + ((gFibSol + gFibIns) * 1.5);
+                    let gComplex = Math.round((oso - kcalUsed) / 4);
+                    if (gComplex < 0) {
+                        gComplex = 0;
+                    }
+                    const kcalFinal = (gProt * 4) + (gSat * 9) + (gUns * 9) + (gSim * 4) + (gComplex * 4) + ((gFibSol + gFibIns) * 1.5);
+                    const rows = [
+                        ['Белки', `${gProt} г`],
+                        ['Жиры насыщенные', `${gSat} г`],
+                        ['Жиры ненасыщенные', `${gUns} г`],
+                        ['Углеводы простые', `${gSim} г`],
+                        ['Углеводы сложные перевариваемые', `${gComplex} г`],
+                        ['Клетчатка растворимая', `${gFibSol} г`],
+                        ['Клетчатка нерастворимая', `${gFibIns} г`],
+                        ['ККал', `${(Math.round(kcalFinal * 10) / 10).toFixed(1)}`]
+                    ];
+                    calculatorSummaryBody.innerHTML = rows.map(([name, value]) => `<tr><td>${name}</td><td class="right">${value}</td></tr>`).join('');
+                }
+
+                updateCalculatorSummary = updateSummary;
+
+                [elSex, elAct, elW, elH, elA, elpProt, elpSat, elpUns, elpSim, elFibTotal, elFibRatio].forEach(element => {
+                    if (element) {
+                        element.addEventListener('input', updateSummary);
+                    }
+                });
+
+                fillActivity();
+                updateSummary();
+
+                const initialTargets = extractTargetsFromSummary(calculatorSummaryBody);
+                if (initialTargets) {
+                    state.currentTargets = initialTargets;
+                    renderTargetSummary(initialTargets);
+                }
+
+                if (openCalculatorButton) {
+                    openCalculatorButton.addEventListener('click', () => {
+                        if (typeof updateCalculatorSummary === 'function') {
+                            updateCalculatorSummary();
+                        }
+                        calculatorDialog.showModal();
+                    });
+                }
+                if (calculatorOkButton) {
+                    calculatorOkButton.addEventListener('click', () => {
+                        if (typeof updateCalculatorSummary === 'function') {
+                            updateCalculatorSummary();
+                        }
+                        const targets = extractTargetsFromSummary(calculatorSummaryBody);
+                        if (targets) {
+                            state.currentTargets = targets;
+                            renderTargetSummary(targets);
+                            resetOptimizationResults();
+                        }
+                        calculatorDialog.close();
+                    });
+                }
+                if (calculatorCancelButton) {
+                    calculatorCancelButton.addEventListener('click', () => {
+                        calculatorDialog.close();
+                    });
+                }
+                calculatorDialog.addEventListener('cancel', event => {
+                    event.preventDefault();
+                    calculatorDialog.close();
+                });
+            }
+
+            function initialise() {
+                if (expandedToggle) {
+                    expandedToggle.addEventListener('change', updateNutrientVisibility);
+                }
+                if (hideDbToggle) {
+                    hideDbToggle.addEventListener('change', updateDbVisibility);
+                }
+                updateNutrientVisibility();
+                updateDbVisibility();
+
+                if (runOptimizationButton) {
+                    runOptimizationButton.addEventListener('click', async () => {
+                        const baseAlpha = parseFloat(residualInput && residualInput.value);
+                        if (!Number.isFinite(baseAlpha) || baseAlpha < 0) {
+                            alert('Введите корректное значение для "Доля остатка".');
+                            return;
+                        }
+                        const runCount = Math.floor(parseFloat(runCountInput && runCountInput.value));
+                        if (!Number.isFinite(runCount) || runCount <= 0) {
+                            alert('Количество прогонов должно быть положительным целым числом.');
+                            return;
+                        }
+                        if (!hasValidTargets(state.currentTargets)) {
+                            alert('Сначала заполните и подтвердите данные в калькуляторе ОСО.');
+                            return;
+                        }
+                        const selectedProducts = gatherOptimizationProducts();
+                        if (!selectedProducts.length) {
+                            alert('Выберите продукты для оптимизации.');
+                            return;
+                        }
+                        const payload = {
+                            residual_share: clampFraction(baseAlpha),
+                            run_count: runCount,
+                            targets: state.currentTargets,
+                            products: selectedProducts.map(item => ({
+                                name: item.name,
+                                step: item.step,
+                                max_weight: item.max_weight,
+                                fix_weight: item.fix_weight,
+                                fixed_weight: item.fixed_weight,
+                                nutrients: {
+                                    proteins: item.nutrients.proteins || 0,
+                                    saturated: item.nutrients.saturated || 0,
+                                    unsaturated: item.nutrients.unsaturated || 0,
+                                    simple: item.nutrients.simple || 0,
+                                    complex: item.nutrients.complex || 0,
+                                    soluble: item.nutrients.soluble || 0,
+                                    insoluble: item.nutrients.insoluble || 0,
+                                    kcal: item.nutrients.kcal || 0
+                                }
+                            }))
+                        };
+
+                        const originalLabel = runOptimizationButton.textContent;
+                        runOptimizationButton.disabled = true;
+                        runOptimizationButton.textContent = 'Расчёт...';
+                        try {
+                            const result = await requestOptimization(payload);
+                            displayOptimizationResult(result, baseAlpha);
+                        } catch (error) {
+                            console.error(error);
+                            alert(error.message || 'Не удалось выполнить оптимизацию.');
+                        } finally {
+                            runOptimizationButton.disabled = false;
+                            runOptimizationButton.textContent = originalLabel;
+                        }
+                    });
+                }
+
+                fetch('Nutrients%20DB.csv')
+                    .then(response => response.text())
+                    .then(text => {
+                        const lines = text.trim().split(/\r?\n/);
+                        if (!lines.length) {
+                            return;
+                        }
+                        lines.shift();
+                        lines.forEach(line => {
+                            if (!line) {
+                                return;
+                            }
+                            const rawCols = line.split(',');
+                            if (rawCols.length < 9) {
+                                return;
+                            }
+                            const cols = rawCols.map(value => value.trim());
+                            const rawName = cols[0] || '';
+                            const name = rawName.replace(/^﻿/, '');
+                            if (!name) {
+                                return;
+                            }
+                            const proteins = parseFloat(cols[1]) || 0;
+                            const saturated = parseFloat(cols[2]) || 0;
+                            const unsaturated = parseFloat(cols[3]) || 0;
+                            const simple = parseFloat(cols[4]) || 0;
+                            const complex = parseFloat(cols[5]) || 0;
+                            const soluble = parseFloat(cols[6]) || 0;
+                            const insoluble = parseFloat(cols[7]) || 0;
+                            const kcal = parseFloat(cols[8]) || 0;
+                            const fats = saturated + unsaturated;
+                            const carbs = simple + complex + soluble + insoluble;
+
+                            state.products[name] = {
+                                proteins,
+                                saturated,
+                                unsaturated,
+                                simple,
+                                complex,
+                                soluble,
+                                insoluble,
+                                kcal,
+                                fats,
+                                carbs
+                            };
+
+                            if (!dbBody) {
+                                return;
+                            }
+                            const tr = document.createElement('tr');
+                            tr.innerHTML = `
+                                <td><button type="button" class="add-product">+</button></td>
+                                <td>${name}</td>
+                                <td>${formatNumber(proteins)}</td>
+                                <td class="collapsed-only">${formatNumber(fats)}</td>
+                                <td class="collapsed-only">${formatNumber(carbs)}</td>
+                                <td class="detailed-col">${formatNumber(saturated)}</td>
+                                <td class="detailed-col">${formatNumber(unsaturated)}</td>
+                                <td class="detailed-col">${formatNumber(simple)}</td>
+                                <td class="detailed-col">${formatNumber(complex)}</td>
+                                <td class="detailed-col">${formatNumber(soluble)}</td>
+                                <td class="detailed-col">${formatNumber(insoluble)}</td>
+                                <td>${formatNumber(kcal)}</td>
+                            `;
+                            dbBody.appendChild(tr);
+                            updateNutrientVisibility();
+
+                            const addButton = tr.querySelector('.add-product');
+                            addButton.addEventListener('click', () => {
+                                addToPool(name);
+                            });
+                        });
+                    })
+                    .catch(error => {
+                        console.error('Не удалось загрузить базу продуктов', error);
+                    });
+            }
+
+            setupCalculator();
+            initialise();
+        })();
     </script>
 </body>
 </html>

--- a/UI.html
+++ b/UI.html
@@ -733,7 +733,9 @@
                 const totalsForResult = result && typeof result.totals === 'object' ? result.totals : null;
                 renderResultTotals(targetsForTotals, totalsForResult);
                 if (bestResultBody && bestResultSection) {
-                    const weights = Array.isArray(result.weights) ? result.weights.filter(item => Number.isFinite(item.weight) && item.weight > 0) : [];
+                    const weights = Array.isArray(result.weights)
+                        ? result.weights.filter(item => Number.isFinite(item.weight) && item.weight >= 0)
+                        : [];
                     if (weights.length) {
                         weights.sort((a, b) => b.weight - a.weight);
                         bestResultBody.innerHTML = weights.map(item => `<tr><td>${item.name}</td><td>${formatNumber(item.weight)}</td></tr>`).join('');

--- a/app_UI.py
+++ b/app_UI.py
@@ -1,12 +1,32 @@
-from flask import Flask, send_from_directory
+from flask import Flask, jsonify, request, send_from_directory
+
+from optimize_nutrients import load_product_database, optimize_from_payload
 
 app = Flask(__name__, static_folder='.', static_url_path='')
 
 
 @app.route('/')
 def index():
-    """Serve the main HTML interface."""
-    return send_from_directory('.', 'index.html')
+    """Serve the optimisation UI."""
+    return send_from_directory('.', 'UI.html')
+
+
+@app.route('/api/optimize', methods=['POST'])
+def api_optimize():
+    """Оптимизировать рацион на основе данных из UI."""
+    payload = request.get_json(silent=True)
+    if payload is None:
+        return jsonify({'error': 'Некорректный JSON.'}), 400
+
+    try:
+        product_db = load_product_database()
+        result = optimize_from_payload(payload, product_db=product_db)
+    except ValueError as exc:  # ошибки валидации данных
+        return jsonify({'error': str(exc)}), 400
+    except Exception:
+        return jsonify({'error': 'Не удалось выполнить оптимизацию.'}), 500
+
+    return jsonify(result)
 
 
 if __name__ == '__main__':

--- a/optimize_nutrients.py
+++ b/optimize_nutrients.py
@@ -2,7 +2,7 @@ import csv
 import math
 import random
 from dataclasses import dataclass
-from typing import Dict, Iterable, List, Optional
+from typing import Dict, Iterable, List, Optional, Set
 
 import numpy as np
 
@@ -120,6 +120,43 @@ def _parse_bool(value: object, default: bool = False) -> bool:
     if isinstance(value, str):
         return value.strip().lower() in {'1', 'true', 'yes', 'y', 'on'}
     return default
+
+
+def _residual_share_sequence(start_fraction: float) -> List[float]:
+    """Построить последовательность долей остатка с шагом 1% до 100%."""
+
+    try:
+        fraction = float(start_fraction or 0.0)
+    except (TypeError, ValueError):
+        fraction = 0.0
+
+    if not math.isfinite(fraction):
+        fraction = 0.0
+
+    fraction = max(0.0, min(1.0, fraction))
+
+    start_percent = fraction * 100.0
+    shares: List[float] = []
+    seen: Set[float] = set()
+
+    def add_share(value: float) -> None:
+        key = round(value, 6)
+        if key not in seen:
+            seen.add(key)
+            shares.append(value)
+
+    add_share(fraction)
+    next_percent = math.ceil(start_percent)
+    for percent in range(int(next_percent), 101):
+        share_value = percent / 100.0
+        if share_value < fraction:
+            continue
+        add_share(share_value)
+
+    if not shares:
+        shares.append(1.0)
+
+    return shares
 
 
 def load_product_database(csv_path: str = DEFAULT_CSV_PATH) -> Dict[str, Dict[str, float]]:
@@ -242,87 +279,87 @@ def optimise_diet(
 
     target_vector = np.array([targets.get(key, 0.0) for key in NUTRIENT_ORDER], dtype=float)
     target_calories = float(targets.get('calories', 0.0))
-    residual_share = max(0.0, min(1.0, float(residual_share)))
+    residual_sequence = _residual_share_sequence(residual_share)
 
     best_score = math.inf
     best_run = 0
-    best_alpha = 0.0
+    best_share = residual_sequence[0] if residual_sequence else 0.0
     best_weights: List[float] = []
     best_totals: Dict[str, float] = {}
 
-    for run_index in range(1, run_count + 1):
-        alpha_candidate = residual_share * (run_index / run_count)
-        totals = {key: 0.0 for key in NUTRIENT_ORDER}
-        totals['calories'] = 0.0
-        weights: List[float] = []
+    for share_fraction in residual_sequence:
+        for run_index in range(1, run_count + 1):
+            totals = {key: 0.0 for key in NUTRIENT_ORDER}
+            totals['calories'] = 0.0
+            weights: List[float] = []
 
-        for product in products:
-            if product.max_weight <= 0:
-                weights.append(0.0)
-                continue
+            for product in products:
+                if product.max_weight <= 0:
+                    weights.append(0.0)
+                    continue
 
-            min_weight = 0.0
-            if (
-                not allow_zero_weights
-                and not product.fix_weight
-                and product.max_weight > 0
-            ):
-                if product.step > 0:
-                    min_weight = min(product.step, product.max_weight)
+                min_weight = 0.0
+                if (
+                    not allow_zero_weights
+                    and not product.fix_weight
+                    and product.max_weight > 0
+                ):
+                    if product.step > 0:
+                        min_weight = min(product.step, product.max_weight)
+                    else:
+                        min_weight = min(product.max_weight, 1.0)
+                    if min_weight <= 0:
+                        min_weight = product.max_weight
+
+                if product.fix_weight:
+                    weight = product.resolved_fixed_weight()
                 else:
-                    min_weight = min(product.max_weight, 1.0)
-                if min_weight <= 0:
-                    min_weight = product.max_weight
+                    candidate = (
+                        product.max_weight * random.random() * share_fraction
+                        if share_fraction > 0
+                        else 0.0
+                    )
+                    weight = _quantize_weight(
+                        candidate,
+                        product.step,
+                        product.max_weight,
+                        min_weight=min_weight,
+                    )
 
-            if product.fix_weight:
-                weight = product.resolved_fixed_weight()
-            else:
-                candidate = (
-                    product.max_weight * random.random() * alpha_candidate
-                    if alpha_candidate > 0
-                    else 0.0
-                )
-                weight = _quantize_weight(
-                    candidate,
-                    product.step,
-                    product.max_weight,
-                    min_weight=min_weight,
-                )
+                weights.append(weight)
+                weight_factor = weight / 100.0
+                for key in NUTRIENT_ORDER:
+                    totals[key] += product.nutrients.get(key, 0.0) * weight_factor
+                kcal_value = product.nutrients.get('kcal')
+                if kcal_value is None:
+                    fats = product.nutrients.get('saturated', 0.0) + product.nutrients.get('unsaturated', 0.0)
+                    carbs = (
+                        product.nutrients.get('simple', 0.0)
+                        + product.nutrients.get('complex', 0.0)
+                        + product.nutrients.get('soluble', 0.0)
+                        + product.nutrients.get('insoluble', 0.0)
+                    )
+                    kcal_value = compute_calories((product.nutrients.get('proteins', 0.0), fats, carbs))
+                totals['calories'] += kcal_value * weight_factor
 
-            weights.append(weight)
-            weight_factor = weight / 100.0
-            for key in NUTRIENT_ORDER:
-                totals[key] += product.nutrients.get(key, 0.0) * weight_factor
-            kcal_value = product.nutrients.get('kcal')
-            if kcal_value is None:
-                fats = product.nutrients.get('saturated', 0.0) + product.nutrients.get('unsaturated', 0.0)
-                carbs = (
-                    product.nutrients.get('simple', 0.0)
-                    + product.nutrients.get('complex', 0.0)
-                    + product.nutrients.get('soluble', 0.0)
-                    + product.nutrients.get('insoluble', 0.0)
-                )
-                kcal_value = compute_calories((product.nutrients.get('proteins', 0.0), fats, carbs))
-            totals['calories'] += kcal_value * weight_factor
+            predicted_vector = np.array([totals[key] for key in NUTRIENT_ORDER], dtype=float)
+            predicted_calories = totals.get('calories')
+            score = rmse(
+                predicted_vector,
+                target_vector,
+                nutrient_keys=NUTRIENT_ORDER,
+                calorie_weight=calorie_weight,
+                predicted_calories=predicted_calories if predicted_calories else None,
+                target_calories=target_calories if target_calories else None,
+            )
+            score = float(score)
 
-        predicted_vector = np.array([totals[key] for key in NUTRIENT_ORDER], dtype=float)
-        predicted_calories = totals.get('calories')
-        score = rmse(
-            predicted_vector,
-            target_vector,
-            nutrient_keys=NUTRIENT_ORDER,
-            calorie_weight=calorie_weight,
-            predicted_calories=predicted_calories if predicted_calories else None,
-            target_calories=target_calories if target_calories else None,
-        )
-        score = float(score)
-
-        if score < best_score:
-            best_score = score
-            best_run = run_index
-            best_alpha = alpha_candidate
-            best_weights = weights.copy()
-            best_totals = totals.copy()
+            if score < best_score:
+                best_score = score
+                best_run = run_index
+                best_share = share_fraction
+                best_weights = weights.copy()
+                best_totals = totals.copy()
 
     weight_summary = [
         {'name': product.name, 'weight': round(weight, 2)}
@@ -335,7 +372,7 @@ def optimise_diet(
     return {
         'rmse': round(best_score, 6) if math.isfinite(best_score) else 0.0,
         'run': best_run,
-        'residual_share': round(best_alpha, 6),
+        'residual_share': round(best_share, 6),
         'weights': weight_summary,
         'totals': result_totals,
     }

--- a/optimize_nutrients.py
+++ b/optimize_nutrients.py
@@ -112,6 +112,16 @@ def _parse_float(value: Optional[str]) -> float:
         return 0.0
 
 
+def _parse_bool(value: object, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() in {'1', 'true', 'yes', 'y', 'on'}
+    return default
+
+
 def load_product_database(csv_path: str = DEFAULT_CSV_PATH) -> Dict[str, Dict[str, float]]:
     """Загрузить базу продуктов из CSV и вернуть словарь с ключами нутриентов."""
     products: Dict[str, Dict[str, float]] = {}
@@ -134,15 +144,35 @@ def load_product_database(csv_path: str = DEFAULT_CSV_PATH) -> Dict[str, Dict[st
     return products
 
 
-def _quantize_weight(weight: float, step: float, max_weight: float) -> float:
-    if weight <= 0:
+def _quantize_weight(
+    weight: float,
+    step: float,
+    max_weight: float,
+    *,
+    min_weight: float = 0.0,
+) -> float:
+    if max_weight <= 0:
         return 0.0
+
+    effective = max(0.0, min(weight, max_weight))
     if step <= 0:
-        return min(weight, max_weight)
-    steps = round(weight / step)
-    quantized = steps * step
-    if quantized > max_weight:
-        quantized = math.floor(max_weight / step) * step
+        quantized = effective
+    else:
+        steps = round(effective / step)
+        quantized = steps * step
+        if quantized > max_weight:
+            quantized = math.floor(max_weight / step) * step
+        quantized = max(0.0, quantized)
+
+    if min_weight > 0:
+        min_weight = max(0.0, min(min_weight, max_weight))
+        if step > 0:
+            min_steps = max(1, math.ceil(min_weight / step))
+            min_candidate = min(max_weight, min_steps * step)
+            min_weight = min_candidate if min_candidate > 0 else min(max_weight, step)
+        if quantized < min_weight:
+            quantized = min_weight
+
     return max(0.0, min(quantized, max_weight))
 
 
@@ -202,6 +232,7 @@ def optimise_diet(
     targets: Dict[str, float],
     run_count: int,
     residual_share: float,
+    allow_zero_weights: bool = True,
     calorie_weight: float = 0.01,
 ) -> Dict[str, object]:
     if not products:
@@ -230,13 +261,33 @@ def optimise_diet(
                 weights.append(0.0)
                 continue
 
+            min_weight = 0.0
+            if (
+                not allow_zero_weights
+                and not product.fix_weight
+                and product.max_weight > 0
+            ):
+                if product.step > 0:
+                    min_weight = min(product.step, product.max_weight)
+                else:
+                    min_weight = min(product.max_weight, 1.0)
+                if min_weight <= 0:
+                    min_weight = product.max_weight
+
             if product.fix_weight:
                 weight = product.resolved_fixed_weight()
-            elif alpha_candidate <= 0:
-                weight = 0.0
             else:
-                candidate = product.max_weight * random.random() * alpha_candidate
-                weight = _quantize_weight(candidate, product.step, product.max_weight)
+                candidate = (
+                    product.max_weight * random.random() * alpha_candidate
+                    if alpha_candidate > 0
+                    else 0.0
+                )
+                weight = _quantize_weight(
+                    candidate,
+                    product.step,
+                    product.max_weight,
+                    min_weight=min_weight,
+                )
 
             weights.append(weight)
             weight_factor = weight / 100.0
@@ -316,13 +367,22 @@ def optimize_from_payload(payload: Dict[str, object], product_db: Optional[Dict[
     except (TypeError, ValueError):
         residual_share = 0.0
 
+    allow_zero_weights = _parse_bool(payload.get('allow_zero_weights'), default=True)
+
     products_payload = payload.get('products')
     if not isinstance(products_payload, list) or not products_payload:
         raise ValueError('Список продуктов пуст.')
 
     products = [_prepare_product(item, product_db) for item in products_payload]
-    result = optimise_diet(products, targets, run_count=run_count, residual_share=residual_share)
+    result = optimise_diet(
+        products,
+        targets,
+        run_count=run_count,
+        residual_share=residual_share,
+        allow_zero_weights=allow_zero_weights,
+    )
     result['targets'] = targets
+    result['allow_zero_weights'] = allow_zero_weights
     return result
 
 

--- a/optimize_nutrients.py
+++ b/optimize_nutrients.py
@@ -1,41 +1,51 @@
+import csv
+import math
+import random
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional
+
 import numpy as np
 
 
-def compute_calories(nutrients):
-    """Calculate calories from macronutrient amounts.
+NUTRIENT_ORDER: tuple[str, ...] = (
+    'proteins',
+    'saturated',
+    'unsaturated',
+    'simple',
+    'complex',
+    'soluble',
+    'insoluble',
+)
+DEFAULT_CSV_PATH = 'Nutrients DB.csv'
 
-    Parameters
-    ----------
-    nutrients : array-like
-        Sequence containing grams of protein, fat and carbohydrates respectively.
 
-    Returns
-    -------
-    float
-        Calculated caloric value.
-    """
+@dataclass
+class OptimizationProduct:
+    """Представление продукта для расчёта рациона."""
+
+    name: str
+    nutrients: Dict[str, float]
+    step: float
+    max_weight: float
+    fix_weight: bool = False
+    fixed_weight: float = 0.0
+
+    def resolved_fixed_weight(self) -> float:
+        """Вернуть вес для фиксированного продукта, ограниченный допустимыми границами."""
+        if not self.fix_weight or self.max_weight <= 0:
+            return 0.0
+        weight = self.fixed_weight if self.fixed_weight > 0 else self.max_weight
+        return min(self.max_weight, max(0.0, weight))
+
+
+def compute_calories(nutrients: Iterable[float]) -> float:
+    """Calculate calories from macronutrient amounts."""
     protein, fat, carbs = nutrients
     return protein * 4 + fat * 9 + carbs * 4
 
 
-def rmse(predicted, target, calorie_weight=None):
-    """Calculate root mean squared error between vectors.
-
-    By default only gram based nutrients are compared.  When ``calorie_weight``
-    is provided the difference in calories is appended to the error vector and
-    scaled by the weight to avoid calories dominating the RMSE.
-
-    Parameters
-    ----------
-    predicted : array-like
-        Predicted nutrient values in grams.
-    target : array-like
-        Target nutrient values in grams.
-    calorie_weight : float, optional
-        When provided, include the difference in calories in the RMSE and scale
-        it by this weight so that its impact is comparable with gram based
-        nutrients.
-    """
+def rmse(predicted: Iterable[float], target: Iterable[float], calorie_weight: Optional[float] = None) -> float:
+    """Calculate root mean squared error between vectors."""
     predicted = np.array(predicted, dtype=float)
     target = np.array(target, dtype=float)
 
@@ -49,19 +59,234 @@ def rmse(predicted, target, calorie_weight=None):
     return np.sqrt(np.mean(diffs ** 2))
 
 
-def main():
-    # Example: protein, fat, carbs in grams
-    predicted = [25, 10, 40]
-    target = [30, 8, 50]
-
-    # Previously calories were appended to ``target`` which distorted RMSE.
-    # Now RMSE is calculated strictly on gram based nutrients.
-    print(f"RMSE without calories: {rmse(predicted, target):.2f}")
-
-    # Caloric contribution can optionally be included using a small weight to
-    # normalise it relative to gram based nutrients.
-    print(f"RMSE with calories (weight 0.01): {rmse(predicted, target, calorie_weight=0.01):.2f}")
+def _parse_float(value: Optional[str]) -> float:
+    try:
+        return float(value or 0)
+    except (TypeError, ValueError):
+        return 0.0
 
 
-if __name__ == "__main__":
+def load_product_database(csv_path: str = DEFAULT_CSV_PATH) -> Dict[str, Dict[str, float]]:
+    """Загрузить базу продуктов из CSV и вернуть словарь с ключами нутриентов."""
+    products: Dict[str, Dict[str, float]] = {}
+    with open(csv_path, newline='', encoding='utf-8') as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            raw_name = (row.get('Продукт') or '').strip().replace('\ufeff', '')
+            if not raw_name:
+                continue
+            products[raw_name] = {
+                'proteins': _parse_float(row.get('Белки')),
+                'saturated': _parse_float(row.get('Насыщенные')),
+                'unsaturated': _parse_float(row.get('НЕнасыщенные')),
+                'simple': _parse_float(row.get('Простые')),
+                'complex': _parse_float(row.get('Сложные перевариваемые')),
+                'soluble': _parse_float(row.get('Растворимая')),
+                'insoluble': _parse_float(row.get('Нерастворимая')),
+                'kcal': _parse_float(row.get('ККал')),
+            }
+    return products
+
+
+def _quantize_weight(weight: float, step: float, max_weight: float) -> float:
+    if weight <= 0:
+        return 0.0
+    if step <= 0:
+        return min(weight, max_weight)
+    steps = round(weight / step)
+    quantized = steps * step
+    if quantized > max_weight:
+        quantized = math.floor(max_weight / step) * step
+    return max(0.0, min(quantized, max_weight))
+
+
+def _normalise_targets(raw: Dict[str, float]) -> Dict[str, float]:
+    result = {}
+    for key in (*NUTRIENT_ORDER, 'calories'):
+        try:
+            result[key] = float(raw.get(key, 0) or 0)
+        except (TypeError, ValueError):
+            result[key] = 0.0
+    return result
+
+
+def _prepare_product(entry: Dict[str, object], product_db: Dict[str, Dict[str, float]]) -> OptimizationProduct:
+    if not isinstance(entry, dict):
+        raise ValueError('Некорректные данные продукта.')
+    name = str(entry.get('name') or '').strip()
+    if not name:
+        raise ValueError('Не указано название продукта.')
+
+    nutrients_data = entry.get('nutrients')
+    if isinstance(nutrients_data, dict):
+        nutrients = {
+            'proteins': _parse_float(nutrients_data.get('proteins')),
+            'saturated': _parse_float(nutrients_data.get('saturated')),
+            'unsaturated': _parse_float(nutrients_data.get('unsaturated')),
+            'simple': _parse_float(nutrients_data.get('simple')),
+            'complex': _parse_float(nutrients_data.get('complex')),
+            'soluble': _parse_float(nutrients_data.get('soluble')),
+            'insoluble': _parse_float(nutrients_data.get('insoluble')),
+            'kcal': _parse_float(nutrients_data.get('kcal')),
+        }
+    else:
+        if name not in product_db:
+            raise ValueError(f'Продукт "{name}" отсутствует в базе.')
+        nutrients = product_db[name]
+
+    step = _parse_float(entry.get('step'))
+    max_weight = max(0.0, _parse_float(entry.get('max_weight')))
+    fix_weight = bool(entry.get('fix_weight'))
+    fixed_weight = _parse_float(entry.get('fixed_weight'))
+    if fix_weight and fixed_weight <= 0:
+        fixed_weight = max_weight
+
+    return OptimizationProduct(
+        name=name,
+        nutrients=nutrients,
+        step=max(0.0, step),
+        max_weight=max_weight,
+        fix_weight=fix_weight,
+        fixed_weight=fixed_weight,
+    )
+
+
+def optimise_diet(
+    products: List[OptimizationProduct],
+    targets: Dict[str, float],
+    run_count: int,
+    residual_share: float,
+    calorie_weight: float = 0.01,
+) -> Dict[str, object]:
+    if not products:
+        raise ValueError('Список продуктов для оптимизации пуст.')
+    if run_count <= 0:
+        raise ValueError('Количество прогонов должно быть положительным.')
+
+    target_vector = np.array([targets.get(key, 0.0) for key in NUTRIENT_ORDER], dtype=float)
+    target_calories = float(targets.get('calories', 0.0))
+    residual_share = max(0.0, min(1.0, float(residual_share)))
+
+    best_score = math.inf
+    best_run = 0
+    best_alpha = 0.0
+    best_weights: List[float] = []
+    best_totals: Dict[str, float] = {}
+
+    for run_index in range(1, run_count + 1):
+        alpha_candidate = residual_share * (run_index / run_count)
+        totals = {key: 0.0 for key in NUTRIENT_ORDER}
+        totals['calories'] = 0.0
+        weights: List[float] = []
+
+        for product in products:
+            if product.max_weight <= 0:
+                weights.append(0.0)
+                continue
+
+            if product.fix_weight:
+                weight = product.resolved_fixed_weight()
+            elif alpha_candidate <= 0:
+                weight = 0.0
+            else:
+                candidate = product.max_weight * random.random() * alpha_candidate
+                weight = _quantize_weight(candidate, product.step, product.max_weight)
+
+            weights.append(weight)
+            weight_factor = weight / 100.0
+            for key in NUTRIENT_ORDER:
+                totals[key] += product.nutrients.get(key, 0.0) * weight_factor
+            kcal_value = product.nutrients.get('kcal')
+            if kcal_value is None:
+                fats = product.nutrients.get('saturated', 0.0) + product.nutrients.get('unsaturated', 0.0)
+                carbs = (
+                    product.nutrients.get('simple', 0.0)
+                    + product.nutrients.get('complex', 0.0)
+                    + product.nutrients.get('soluble', 0.0)
+                    + product.nutrients.get('insoluble', 0.0)
+                )
+                kcal_value = compute_calories((product.nutrients.get('proteins', 0.0), fats, carbs))
+            totals['calories'] += kcal_value * weight_factor
+
+        predicted_vector = np.array([totals[key] for key in NUTRIENT_ORDER], dtype=float)
+        score = rmse(predicted_vector, target_vector, calorie_weight=calorie_weight)
+        score = float(score)
+
+        if score < best_score:
+            best_score = score
+            best_run = run_index
+            best_alpha = alpha_candidate
+            best_weights = weights.copy()
+            best_totals = totals.copy()
+
+    weight_summary = [
+        {'name': product.name, 'weight': round(weight, 2)}
+        for product, weight in zip(products, best_weights)
+    ]
+
+    result_totals = {key: round(best_totals.get(key, 0.0), 4) for key in (*NUTRIENT_ORDER, 'calories')}
+    result_totals['calories'] = round(best_totals.get('calories', target_calories), 4)
+
+    return {
+        'rmse': round(best_score, 6) if math.isfinite(best_score) else 0.0,
+        'run': best_run,
+        'residual_share': round(best_alpha, 6),
+        'weights': weight_summary,
+        'totals': result_totals,
+    }
+
+
+def optimize_from_payload(payload: Dict[str, object], product_db: Optional[Dict[str, Dict[str, float]]] = None) -> Dict[str, object]:
+    """Построить рацион на основании данных из UI."""
+    if not isinstance(payload, dict):
+        raise ValueError('Некорректные данные запроса.')
+
+    if product_db is None:
+        product_db = load_product_database()
+
+    targets_raw = payload.get('targets')
+    if not isinstance(targets_raw, dict):
+        raise ValueError('Целевые значения не переданы.')
+    targets = _normalise_targets(targets_raw)
+
+    try:
+        run_count = int(payload.get('run_count', 10))
+    except (TypeError, ValueError):
+        run_count = 10
+    if run_count <= 0:
+        raise ValueError('Количество прогонов должно быть положительным.')
+
+    residual_share = payload.get('residual_share', 0.0)
+    try:
+        residual_share = float(residual_share)
+    except (TypeError, ValueError):
+        residual_share = 0.0
+
+    products_payload = payload.get('products')
+    if not isinstance(products_payload, list) or not products_payload:
+        raise ValueError('Список продуктов пуст.')
+
+    products = [_prepare_product(item, product_db) for item in products_payload]
+    result = optimise_diet(products, targets, run_count=run_count, residual_share=residual_share)
+    result['targets'] = targets
+    return result
+
+
+def main() -> None:
+    """Небольшой пример использования."""
+    sample_products = [
+        OptimizationProduct(
+            name='Sample Product',
+            nutrients={'proteins': 20, 'saturated': 5, 'unsaturated': 5, 'simple': 10, 'complex': 40, 'soluble': 5, 'insoluble': 5, 'kcal': 350},
+            step=10,
+            max_weight=200,
+        )
+    ]
+    sample_targets = {key: 50 for key in NUTRIENT_ORDER}
+    sample_targets['calories'] = 2000
+    result = optimise_diet(sample_products, sample_targets, run_count=5, residual_share=0.5)
+    print(result)
+
+
+if __name__ == '__main__':
     main()

--- a/optimize_nutrients.py
+++ b/optimize_nutrients.py
@@ -44,19 +44,65 @@ def compute_calories(nutrients: Iterable[float]) -> float:
     return protein * 4 + fat * 9 + carbs * 4
 
 
-def rmse(predicted: Iterable[float], target: Iterable[float], calorie_weight: Optional[float] = None) -> float:
-    """Calculate root mean squared error between vectors."""
-    predicted = np.array(predicted, dtype=float)
-    target = np.array(target, dtype=float)
+def _macro_tuple_from_vector(vector: Iterable[float], nutrient_keys: Iterable[str]) -> tuple[float, float, float]:
+    """Построить кортеж (белки, жиры, углеводы) из вектора нутриентов."""
 
-    diffs = predicted - target
+    index_map = {key: idx for idx, key in enumerate(nutrient_keys)}
+
+    def _value(key: str) -> float:
+        position = index_map.get(key)
+        if position is None:
+            return 0.0
+        try:
+            return float(vector[position])
+        except (TypeError, ValueError):
+            return 0.0
+
+    protein = _value('proteins')
+    fats = _value('saturated') + _value('unsaturated')
+    carbs = sum(_value(key) for key in ('simple', 'complex', 'soluble', 'insoluble'))
+
+    return protein, fats, carbs
+
+
+def rmse(
+    predicted: Iterable[float],
+    target: Iterable[float],
+    *,
+    nutrient_keys: Optional[Iterable[str]] = None,
+    calorie_weight: Optional[float] = None,
+    predicted_calories: Optional[float] = None,
+    target_calories: Optional[float] = None,
+) -> float:
+    """Calculate root mean squared error between nutrient vectors."""
+
+    predicted_arr = np.array(predicted, dtype=float)
+    target_arr = np.array(target, dtype=float)
+
+    diffs = predicted_arr - target_arr
 
     if calorie_weight is not None:
-        pred_calories = compute_calories(predicted)
-        target_calories = compute_calories(target)
-        diffs = np.append(diffs, (pred_calories - target_calories) * calorie_weight)
+        try:
+            cal_weight = float(calorie_weight)
+        except (TypeError, ValueError):
+            cal_weight = 0.0
 
-    return np.sqrt(np.mean(diffs ** 2))
+        if math.isfinite(cal_weight) and cal_weight != 0.0:
+            cal_weight = abs(cal_weight)
+            if predicted_calories is None or target_calories is None:
+                if nutrient_keys is None:
+                    raise ValueError('nutrient_keys are required to compute calories automatically')
+                protein_pred, fat_pred, carb_pred = _macro_tuple_from_vector(predicted_arr, nutrient_keys)
+                protein_target, fat_target, carb_target = _macro_tuple_from_vector(target_arr, nutrient_keys)
+                if predicted_calories is None:
+                    predicted_calories = compute_calories((protein_pred, fat_pred, carb_pred))
+                if target_calories is None:
+                    target_calories = compute_calories((protein_target, fat_target, carb_target))
+
+            calories_diff = (float(predicted_calories or 0.0) - float(target_calories or 0.0)) * cal_weight
+            diffs = np.append(diffs, calories_diff)
+
+    return float(np.sqrt(np.mean(diffs ** 2)))
 
 
 def _parse_float(value: Optional[str]) -> float:
@@ -209,7 +255,15 @@ def optimise_diet(
             totals['calories'] += kcal_value * weight_factor
 
         predicted_vector = np.array([totals[key] for key in NUTRIENT_ORDER], dtype=float)
-        score = rmse(predicted_vector, target_vector, calorie_weight=calorie_weight)
+        predicted_calories = totals.get('calories')
+        score = rmse(
+            predicted_vector,
+            target_vector,
+            nutrient_keys=NUTRIENT_ORDER,
+            calorie_weight=calorie_weight,
+            predicted_calories=predicted_calories if predicted_calories else None,
+            target_calories=target_calories if target_calories else None,
+        )
         score = float(score)
 
         if score < best_score:


### PR DESCRIPTION
## Summary
- embed the OSO calculator inside UI.html as a modal, show the chosen targets, reorder kcal columns, and add a table with the best product weights
- rework the client script to submit calculator targets and pool selections to the backend optimisation API and display the minimal-RMSE result
- expose an /api/optimize endpoint that uses the enhanced optimise_diet logic in optimize_nutrients.py, which now loads product data, parses requests, and runs the random-search optimiser

## Testing
- python -m compileall app_UI.py optimize_nutrients.py

------
https://chatgpt.com/codex/tasks/task_e_68cb005086fc832c8504d093f54f3df5