### PR TITLE
Add nutrient contribution breakdown table

### DIFF
--- a/UI.html
+++ b/UI.html
@@ -339,12 +339,33 @@
             <tbody id="best-result-body"></tbody>
         </table>
     </div>
+    <div id="best-result-breakdown" class="hidden">
+        <h3>Вклад продуктов в нутриенты</h3>
+        <table>
+            <thead>
+                <tr>
+                    <th>Продукт</th>
+                    <th>Белки</th>
+                    <th>Жиры насыщенные</th>
+                    <th>Жиры ненасыщенные</th>
+                    <th>Углеводы простые</th>
+                    <th>Углеводы сложные перевариваемые</th>
+                    <th>Клетчатка растворимая</th>
+                    <th>Клетчатка нерастворимая</th>
+                    <th>ККал</th>
+                </tr>
+            </thead>
+            <tbody id="best-result-nutrients-body"></tbody>
+            <tfoot id="best-result-nutrients-footer"></tfoot>
+        </table>
+    </div>
 
         <script>
         (function() {
             'use strict';
 
             const NUTRIENT_KEYS = ['proteins', 'saturated', 'unsaturated', 'simple', 'complex', 'soluble', 'insoluble'];
+            const ALL_NUTRIENT_KEYS = [...NUTRIENT_KEYS, 'calories'];
             const SUMMARY_LABELS = {
                 proteins: 'Белки',
                 saturated: 'Жиры насыщенные',
@@ -411,6 +432,9 @@
             const resultTotalsBody = document.getElementById('result-totals-body');
             const bestResultSection = document.getElementById('best-result');
             const bestResultBody = document.getElementById('best-result-body');
+            const bestResultBreakdownSection = document.getElementById('best-result-breakdown');
+            const bestResultBreakdownBody = document.getElementById('best-result-nutrients-body');
+            const bestResultBreakdownFooter = document.getElementById('best-result-nutrients-footer');
             const targetSummarySection = document.getElementById('target-summary');
             const targetSummaryBody = document.getElementById('target-summary-body');
             const openCalculatorButton = document.getElementById('open-calculator');
@@ -451,6 +475,15 @@
                 if (bestResultBody) {
                     bestResultBody.innerHTML = '';
                 }
+                if (bestResultBreakdownSection) {
+                    bestResultBreakdownSection.classList.add('hidden');
+                }
+                if (bestResultBreakdownBody) {
+                    bestResultBreakdownBody.innerHTML = '';
+                }
+                if (bestResultBreakdownFooter) {
+                    bestResultBreakdownFooter.innerHTML = '';
+                }
             }
 
             function renderTargetSummary(targets) {
@@ -462,8 +495,7 @@
                     targetSummaryBody.innerHTML = '';
                     return;
                 }
-                const order = ['proteins', 'saturated', 'unsaturated', 'simple', 'complex', 'soluble', 'insoluble', 'calories'];
-                const rows = order.map(key => {
+                const rows = ALL_NUTRIENT_KEYS.map(key => {
                     const label = SUMMARY_LABELS[key] || key;
                     const value = formatValueWithUnit(targets[key], key);
                     return `<tr><td>${label}</td><td class="right">${value}</td></tr>`;
@@ -481,8 +513,7 @@
                     resultTotalsBody.innerHTML = '';
                     return;
                 }
-                const order = [...NUTRIENT_KEYS, 'calories'];
-                const rows = order.map(key => {
+                const rows = ALL_NUTRIENT_KEYS.map(key => {
                     const label = SUMMARY_LABELS[key] || key;
                     const targetValue = formatValueWithUnit(targets[key], key);
                     const totalValue = formatValueWithUnit(totals[key], key);
@@ -490,6 +521,125 @@
                 }).join('');
                 resultTotalsBody.innerHTML = rows;
                 resultTotalsSection.classList.remove('hidden');
+            }
+
+            function renderBestNutrientBreakdown(result, weights) {
+                if (!bestResultBreakdownSection || !bestResultBreakdownBody) {
+                    return;
+                }
+                const breakdown = result && typeof result === 'object' ? result.nutrient_breakdown : null;
+                const hasBreakdownData = Boolean(breakdown && Array.isArray(breakdown.products) && breakdown.products.length);
+                const hasWeightData = Array.isArray(weights) && weights.length > 0;
+
+                if (!hasBreakdownData && !hasWeightData) {
+                    bestResultBreakdownSection.classList.add('hidden');
+                    bestResultBreakdownBody.innerHTML = '';
+                    if (bestResultBreakdownFooter) {
+                        bestResultBreakdownFooter.innerHTML = '';
+                    }
+                    return;
+                }
+
+                const nutrientOrder = ALL_NUTRIENT_KEYS;
+                const columnCount = nutrientOrder.length + 1;
+                let rows = [];
+                let totals = null;
+
+                if (hasBreakdownData) {
+                    const weightOrder = hasWeightData ? weights.map(item => item.name) : null;
+                    rows = breakdown.products.map(entry => {
+                        const name = entry && typeof entry.name === 'string' ? entry.name : String(entry && entry.name ? entry.name : '');
+                        const nutrients = entry && typeof entry.nutrients === 'object' ? entry.nutrients : {};
+                        const values = nutrientOrder.map(key => {
+                            const numeric = Number(nutrients[key]);
+                            return Number.isFinite(numeric) ? numeric : 0;
+                        });
+                        return {
+                            name,
+                            values,
+                            orderIndex: weightOrder ? weightOrder.indexOf(name) : -1
+                        };
+                    });
+                    if (weightOrder) {
+                        rows.sort((a, b) => {
+                            const aIndex = a.orderIndex >= 0 ? a.orderIndex : Number.MAX_SAFE_INTEGER;
+                            const bIndex = b.orderIndex >= 0 ? b.orderIndex : Number.MAX_SAFE_INTEGER;
+                            if (aIndex !== bIndex) {
+                                return aIndex - bIndex;
+                            }
+                            return a.name.localeCompare(b.name);
+                        });
+                    } else {
+                        rows.sort((a, b) => a.name.localeCompare(b.name));
+                    }
+                    if (breakdown.totals && typeof breakdown.totals === 'object') {
+                        totals = nutrientOrder.reduce((acc, key) => {
+                            const numeric = Number(breakdown.totals[key]);
+                            acc[key] = Number.isFinite(numeric) ? numeric : 0;
+                            return acc;
+                        }, {});
+                    }
+                } else if (hasWeightData) {
+                    rows = weights.map(item => {
+                        const name = item && typeof item.name === 'string' ? item.name : '';
+                        const grams = Number(item.weight) || 0;
+                        const product = state.products[name] || {};
+                        const values = nutrientOrder.map(key => {
+                            let per100 = 0;
+                            if (product && typeof product === 'object') {
+                                if (key === 'calories') {
+                                    const raw = product.calories ?? product.kcal;
+                                    per100 = Number(raw) || 0;
+                                } else {
+                                    per100 = Number(product[key]) || 0;
+                                }
+                            }
+                            return grams * per100 / 100;
+                        });
+                        return { name, values };
+                    });
+                }
+
+                if (!rows.length) {
+                    bestResultBreakdownBody.innerHTML = `<tr><td colspan="${columnCount}">Данные отсутствуют</td></tr>`;
+                    if (bestResultBreakdownFooter) {
+                        bestResultBreakdownFooter.innerHTML = '';
+                    }
+                    bestResultBreakdownSection.classList.remove('hidden');
+                    return;
+                }
+
+                if (!totals) {
+                    totals = nutrientOrder.reduce((acc, key) => {
+                        acc[key] = 0;
+                        return acc;
+                    }, {});
+                    rows.forEach(row => {
+                        row.values.forEach((value, index) => {
+                            const key = nutrientOrder[index];
+                            const numeric = Number(value);
+                            if (Number.isFinite(numeric)) {
+                                totals[key] += numeric;
+                            }
+                        });
+                    });
+                }
+
+                const bodyHtml = rows.map(row => {
+                    const cells = row.values.map((value, index) => {
+                        const key = nutrientOrder[index];
+                        return `<td class="right">${formatValueWithUnit(value, key)}</td>`;
+                    }).join('');
+                    return `<tr><td>${row.name}</td>${cells}</tr>`;
+                }).join('');
+                bestResultBreakdownBody.innerHTML = bodyHtml;
+
+                if (bestResultBreakdownFooter) {
+                    const footerCells = nutrientOrder.map(key => `<td class="right">${formatValueWithUnit(totals[key], key)}</td>`).join('');
+                    bestResultBreakdownFooter.innerHTML = `<tr><th scope="row">Итого</th>${footerCells}</tr>`;
+                }
+
+                bestResultBreakdownSection.classList.remove('hidden');
             }
 
             function extractTargetsFromSummary(summaryElement) {
@@ -732,18 +882,35 @@
                 const targetsForTotals = (result && typeof result.targets === 'object') ? result.targets : state.currentTargets;
                 const totalsForResult = result && typeof result.totals === 'object' ? result.totals : null;
                 renderResultTotals(targetsForTotals, totalsForResult);
+                const weights = Array.isArray(result.weights)
+                    ? result.weights
+                        .map(item => {
+                            const weightValue = Number(item && item.weight);
+                            const nameValue = item && typeof item.name === 'string' ? item.name : String(item && item.name ? item.name : '');
+                            return {
+                                name: nameValue,
+                                weight: Number.isFinite(weightValue) ? weightValue : NaN
+                            };
+                        })
+                        .filter(entry => Number.isFinite(entry.weight) && entry.weight >= 0)
+                    : [];
+                if (weights.length > 1) {
+                    weights.sort((a, b) => {
+                        if (b.weight !== a.weight) {
+                            return b.weight - a.weight;
+                        }
+                        return a.name.localeCompare(b.name);
+                    });
+                }
                 if (bestResultBody && bestResultSection) {
-                    const weights = Array.isArray(result.weights)
-                        ? result.weights.filter(item => Number.isFinite(item.weight) && item.weight >= 0)
-                        : [];
                     if (weights.length) {
-                        weights.sort((a, b) => b.weight - a.weight);
                         bestResultBody.innerHTML = weights.map(item => `<tr><td>${item.name}</td><td>${formatNumber(item.weight)}</td></tr>`).join('');
                     } else {
                         bestResultBody.innerHTML = '<tr><td colspan="2">Данные отсутствуют</td></tr>';
                     }
                     bestResultSection.classList.remove('hidden');
                 }
+                renderBestNutrientBreakdown(result, weights);
             }
 
             function hasValidTargets(targets) {
@@ -1080,6 +1247,7 @@
                                 soluble,
                                 insoluble,
                                 kcal,
+                                calories: kcal,
                                 fats,
                                 carbs
                             };

--- a/optimize_nutrients.py
+++ b/optimize_nutrients.py
@@ -1,3 +1,5 @@
+from typing import Dict, Mapping
+
 from GENESIS_optimize_nutrients import (
     CALORIE_KEY,
     DEFAULT_CSV_PATH,
@@ -7,8 +9,93 @@ from GENESIS_optimize_nutrients import (
     load_product_database,
     main,
     optimise_diet,
-    optimize_from_payload,
+    optimize_from_payload as _optimize_from_payload,
 )
+
+
+_NUTRIENT_BREAKDOWN_KEYS = (*NUTRIENT_ORDER, CALORIE_KEY)
+
+
+def _safe_float(value: object) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _resolve_product_nutrients(
+    product_db: Mapping[str, Mapping[str, float]] | None, name: str
+) -> Mapping[str, float] | None:
+    if not isinstance(product_db, Mapping):
+        return None
+    data = product_db.get(name)
+    if isinstance(data, Mapping):
+        return data
+    return None
+
+
+def _build_nutrient_breakdown(
+    weights: object,
+    product_db: Mapping[str, Mapping[str, float]] | None,
+) -> Dict[str, object]:
+    rows: list[Dict[str, object]] = []
+    totals: Dict[str, float] = {key: 0.0 for key in _NUTRIENT_BREAKDOWN_KEYS}
+
+    if isinstance(weights, Mapping):
+        iterable = []
+    elif isinstance(weights, (list, tuple)):
+        iterable = weights
+    else:
+        try:
+            iterable = list(weights or [])  # type: ignore[arg-type]
+        except TypeError:
+            iterable = []
+
+    for entry in iterable:
+        if not isinstance(entry, Mapping):
+            continue
+        name = str(entry.get('name') or '').strip()
+        if not name and 'weight' not in entry:
+            continue
+        weight = max(0.0, _safe_float(entry.get('weight')))
+        nutrients: Dict[str, float] = {}
+        product_info = _resolve_product_nutrients(product_db, name)
+
+        for key in _NUTRIENT_BREAKDOWN_KEYS:
+            if isinstance(product_info, Mapping):
+                if key == CALORIE_KEY:
+                    raw_value = product_info.get('calories')
+                    if raw_value is None:
+                        raw_value = product_info.get('kcal')
+                else:
+                    raw_value = product_info.get(key)
+            else:
+                raw_value = 0.0
+            per_100 = _safe_float(raw_value)
+            contribution = weight * per_100 / 100.0
+            contribution = round(contribution, 6)
+            nutrients[key] = contribution
+            totals[key] += contribution
+
+        rows.append({'name': name, 'weight': round(weight, 4), 'nutrients': nutrients})
+
+    totals = {key: round(value, 6) for key, value in totals.items()}
+    return {'products': rows, 'totals': totals}
+
+
+def optimize_from_payload(
+    payload: Dict[str, object],
+    product_db: Mapping[str, Mapping[str, float]] | None = None,
+) -> Dict[str, object]:
+    if product_db is None:
+        product_db = load_product_database()
+
+    result = _optimize_from_payload(payload, product_db=product_db)
+
+    weights = result.get('weights') if isinstance(result, Mapping) else None
+    breakdown = _build_nutrient_breakdown(weights, product_db)
+    result['nutrient_breakdown'] = breakdown
+    return result
 
 __all__ = [
     'CALORIE_KEY',

--- a/test_app.py
+++ b/test_app.py
@@ -5,6 +5,8 @@ import importlib
 
 import pytest
 
+import optimize_nutrients
+
 FIELDNAMES = ["Продукт","Белки","Насыщенные","НЕнасыщенные","Простые",
               "Сложные перевариваемые","Растворимая","Нерастворимая",
               "ККал","Макс. порций","Шаг"]
@@ -67,3 +69,56 @@ def test_crud_flow(client):
 
     resp = client.get('/api/products')
     assert len(resp.get_json()) == base_count
+
+
+def test_optimize_returns_breakdown():
+    payload = {
+        'targets': {
+            'proteins': 10,
+            'saturated': 5,
+            'unsaturated': 5,
+            'simple': 5,
+            'complex': 5,
+            'soluble': 5,
+            'insoluble': 5,
+            'calories': 100,
+        },
+        'run_count': 1,
+        'residual_share': 0,
+        'allow_zero_weights': True,
+        'products': [
+            {
+                'name': 'Test Product',
+                'step': 1,
+                'max_weight': 100,
+                'fix_weight': True,
+                'fixed_weight': 100,
+            }
+        ],
+    }
+    product_db = {
+        'Test Product': {
+            'proteins': 10,
+            'saturated': 5,
+            'unsaturated': 5,
+            'simple': 5,
+            'complex': 5,
+            'soluble': 5,
+            'insoluble': 5,
+            'calories': 100,
+            'kcal': 100,
+        }
+    }
+
+    result = optimize_nutrients.optimize_from_payload(payload, product_db=product_db)
+
+    assert 'nutrient_breakdown' in result
+    breakdown = result['nutrient_breakdown']
+    assert isinstance(breakdown, dict)
+    assert breakdown['products'], 'breakdown should contain product rows'
+    product_row = breakdown['products'][0]
+    assert pytest.approx(product_row['nutrients']['proteins'], rel=1e-4) == 10
+    assert pytest.approx(product_row['nutrients']['calories'], rel=1e-4) == 100
+    totals = breakdown['totals']
+    assert pytest.approx(totals['proteins'], rel=1e-4) == 10
+    assert pytest.approx(totals['calories'], rel=1e-4) == 100


### PR DESCRIPTION
## Summary
- compute nutrient contribution breakdowns alongside optimization results
- render a new UI table that lists nutrient contributions per product with totals
- add a unit test that covers the new breakdown payload structure

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb3cc37038832cb6517ec8f7674eb7